### PR TITLE
switch around login buttons

### DIFF
--- a/huggle/login.ui
+++ b/huggle/login.ui
@@ -96,7 +96,7 @@
   <widget class="QPushButton" name="ButtonOK">
    <property name="geometry">
     <rect>
-     <x>150</x>
+     <x>260</x>
      <y>480</y>
      <width>91</width>
      <height>31</height>
@@ -112,7 +112,7 @@
   <widget class="QPushButton" name="ButtonExit">
    <property name="geometry">
     <rect>
-     <x>250</x>
+     <x>150</x>
      <y>480</y>
      <width>101</width>
      <height>31</height>


### PR DESCRIPTION
Just switched the 'Login' and 'Exit' buttons around, as muscle memory expects that the button that performs an action other than cancel will be on the right hand side of a dialog. Also it appears that this is general convention in programs.
