### PR TITLE
Update the CSS to match the one used by MediaWiki on diff pages

### DIFF
--- a/huggle/Resources/Header.txt
+++ b/huggle/Resources/Header.txt
@@ -1,10 +1,103 @@
 <html>
   <head>
   <style type="text/css">
-  table.diff{background:white}td.diff-otitle{background:#ffffff}td.diff-ntitle{background:#ffffff}
-  td.diff-addedline{background:#ccffcc;font-size:smaller;border:solid 2px black}
-  td.diff-deletedline{background:#ffffaa;font-size:smaller;border:dotted 2px black}
-  td.diff-context{background:#eeeeee;font-size:smaller}.diffchange{color:red;font-weight:bold;text-decoration:underline}
+/* Copied from https://git.wikimedia.org/blob/mediawiki%2Fcore.git/HEAD/resources%2Fmediawiki.action%2Fmediawiki.action.history.diff.css
+ * which is released under GNU General Public License v2
+ */
+/*
+** Diff rendering
+*/
+table.diff {
+	background-color: white;
+	border: none;
+	border-spacing: 4px;
+	margin: 0;
+	width: 100%;
+	/* Ensure that colums are of equal width */
+	table-layout: fixed;
+}
+
+table.diff td {
+	padding: 0.33em 0.5em;
+}
+
+table.diff td.diff-marker {
+	/* Compensate padding for increased font-size */
+	padding: 0.25em;
+}
+
+table.diff col.diff-marker {
+	width: 2%;
+}
+
+table.diff col.diff-content {
+	width: 48%;
+}
+
+table.diff td div {
+	/* Force-wrap very long lines such as URLs or page-widening char strings */
+	word-wrap: break-word;
+}
+
+td.diff-otitle,
+td.diff-ntitle {
+	text-align: center;
+}
+
+td.diff-lineno {
+	font-weight: bold;
+}
+
+td.diff-marker {
+	text-align: right;
+	font-weight: bold;
+	font-size: 1.25em;
+}
+
+td.diff-addedline,
+td.diff-deletedline,
+td.diff-context {
+	font-size: 88%;
+	vertical-align: top;
+	white-space: -moz-pre-wrap;
+	white-space: pre-wrap;
+	border-style: solid;
+	border-width: 1px 1px 1px 4px;
+	border-radius: 0.33em;
+}
+
+td.diff-addedline {
+	border-color: #a3d3ff;
+}
+
+td.diff-deletedline {
+	border-color: #ffe49c;
+}
+
+td.diff-context {
+	background: #f9f9f9;
+	border-color: #e6e6e6;
+	color: #333333;
+}
+
+.diffchange {
+	font-weight: bold;
+	text-decoration: none;
+}
+
+td.diff-addedline .diffchange,
+td.diff-deletedline .diffchange {
+	border-radius: 0.33em;
+	padding: 0.25em 0;
+}
+
+td.diff-addedline .diffchange {
+	background: #d8ecff;
+}
+
+td.diff-deletedline .diffchange {
+	background: #feeec8;
+}
   </style>
   </head>
   <body>


### PR DESCRIPTION
The code was copied from
[mediawiki/core.git / resources / mediawiki.action / mediawiki.action.history.diff.css](https://git.wikimedia.org/blob/mediawiki%2Fcore.git/6985d304dbf855562432464d868ad5eae704a416/resources%2Fmediawiki.action%2Fmediawiki.action.history.diff.css)

This fixes [bug 55924](https://bugzilla.wikimedia.org/show_bug.cgi?id=55924).
