### PR TITLE
Use different travis environments for QT4 vs QT5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,23 @@
 # See http://about.travis-ci.org/docs/user/build-configuration/
+# See ./travis/* for the actual scripts that get run
 
 language: cpp
 
-before_install: 
-  - "sudo apt-get update"
+env:
+  - THENEEDFORTHIS=FAIL
 
-install:
-  - "sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa"
-  - "sudo apt-get update -qq"
-  - "sudo apt-get install -y g++ libqt4-dbus libqt4-dev libqt4-network libqt4-opengl libqt4-webkit libqtwebkit-dev libqtgui4 libqtcore4 libqt4-xml qt4-dev-tools qt4-qmake libqt5webkit5-dev qt5-default qtquick1-5-dev qtlocation5-dev qtsensors5-dev qtdeclarative5-dev libsqlite3-dev"
+matrix:
+  include:
+    - env: QTTYPE=4
+    - env: QTTYPE=5
+  exclude:
+    - env: THENEEDFORTHIS=FAIL
 
-before_script: 
-  - "cd /home/travis/build/huggle/huggle3-qt-lx/huggle"
-  - "cp -r /home/travis/build/huggle/huggle3-qt-lx/huggle /home/travis/build/huggle/huggle3-qt-lx/huggle-5"
-  - "./configure --qmake /usr/lib/x86_64-linux-gnu/qt4/bin/qmake"
-  - make
-  - "cd tests/test"
-  - /usr/lib/x86_64-linux-gnu/qt4/bin/qmake
-  - make
-  - "cd /home/travis/build/huggle/huggle3-qt-lx/huggle-5"
-  - "./configure --qt5 --qmake /usr/lib/x86_64-linux-gnu/qt5/bin/qmake"
-  - make
-  - "cd tests/test"
-  - /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
-  - make
+before_install: bash ./travis/before_install.sh
+install: bash ./travis/install.sh
 
-script: 
-  - "echo Testing qmake4"
-  - "cd /home/travis/build/huggle/huggle3-qt-lx/huggle/tests/test"
-  - ./tst_testmain
-  - "echo Testing qmake5"
-  - "cd /home/travis/build/huggle/huggle3-qt-lx/huggle-5/tests/test"
-  - ./tst_testmain
+before_script: bash ./travis/before_script.sh
+script: bash ./travis/script.sh
 
 notifications: 
   irc: 

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+if [ "$QTTYPE" = "5" ]; then
+	sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa
+fi
+
+sudo apt-get update

--- a/travis/before_script.sh
+++ b/travis/before_script.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+
+cd /home/travis/build/huggle/huggle3-qt-lx/huggle
+
+if [ "$QTTYPE" = "4" ]; then
+	./configure --qt4
+	make
+	cd tests/test
+	qmake
+	make
+fi
+
+if [ "$QTTYPE" = "5" ]; then
+	./configure --qt5 --qmake /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
+	make
+	cd tests/test
+	/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
+	make
+fi

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+if [ "$QTTYPE" = "4" ]; then
+	sudo apt-get install -y libqt4-webkit libqtwebkit-dev qt4-qmake qt4-dev-tools
+fi
+
+if [ "$QTTYPE" = "5" ]; then
+	sudo apt-get install -y ubuntu-sdk qtquick1-5-dev
+fi

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+cd /home/travis/build/huggle/huggle3-qt-lx/huggle/tests/test
+
+echo Testing QTTYPE $QTTYPE
+
+./tst_testmain


### PR DESCRIPTION
This also splits each part of the travis execution
into its own bash script for easier reading and use!
