### PR TITLE
use huggle3.css instead of huggle.css as user config page

### DIFF
--- a/huggle/Localization/en.txt
+++ b/huggle/Localization/en.txt
@@ -749,7 +749,7 @@ missing-aiv:               This project doesn't support AIV system
 merging:                   Merging
 missing-page:              There is no page $1 on this wiki
 updating-wl:               Updating whitelist...
-updating-uc:               Updating user configuration page at huggle.css on wiki
+updating-uc:               Updating user configuration page at huggle3.css on wiki
 feature-nfru:              This feature is for ip users only
 report-no-user:            No user has been selected to report, please select some user first
 welcome-tp-empty-fail:     This user doesn't have empty talk page, are you sure you want to send a message to him?

--- a/huggle/configuration.cpp
+++ b/huggle/configuration.cpp
@@ -68,7 +68,8 @@ Configuration::Configuration()
     this->GlobalConfig_LocalConfigWikiPath = "Project:Huggle/Config";
     this->GlobalConfig_DocumentationPath = "https://www.mediawiki.org/wiki/Manual:Huggle";
     this->GlobalConfig_FeedbackPath = "http://en.wikipedia.org/wiki/Wikipedia:Huggle/Feedback";
-    this->GlobalConfig_UserConf = "User:$1/huggle3.css";
+    this->GlobalConfig_UserConf = "User:$1/huggle3.css";        // user-config-hg3
+    this->GlobalConfig_UserConf_old = "User:$1/huggle.css";    // user-config
 
     // Local
     this->LocalConfig_MinimalVersion = "3.0.0.0";
@@ -574,7 +575,15 @@ bool Configuration::ParseGlobalConfig(QString config)
     {
         Configuration::HuggleConfiguration->GlobalConfig_FeedbackPath = temp;
     }
-    // user-config isn't loaded here, but better so to use users huggle3.css instead
+
+    QString userConf = Configuration::ConfigurationParse("user-config-hg3", config);
+    QString userConf_old = Configuration::ConfigurationParse("user-config", config);
+    // Sanitize page titles (huggle2 done sth. similiar at Page.SanitizeTitle before requesting them)
+    Configuration::HuggleConfiguration->GlobalConfig_UserConf =
+            userConf.replace("Special:Mypage", "User:$1").replace("Special:Mytalk", "User talk:$1");
+    Configuration::HuggleConfiguration->GlobalConfig_UserConf_old =
+            userConf_old.replace("Special:Mypage", "User:$1").replace("Special:Mytalk", "User talk:$1");
+
     Configuration::HuggleConfiguration->GlobalConfigWasLoaded = true;
     return true;
 }

--- a/huggle/configuration.hpp
+++ b/huggle/configuration.hpp
@@ -447,6 +447,7 @@ namespace Huggle
             QString     GlobalConfig_DocumentationPath;
             QString     GlobalConfig_FeedbackPath;
             QString     GlobalConfig_UserConf;
+            QString     GlobalConfig_UserConf_old;
             bool        GlobalConfigWasLoaded;
 
             //////////////////////////////////////////////

--- a/huggle/login.hpp
+++ b/huggle/login.hpp
@@ -122,6 +122,8 @@ namespace Huggle
             QString Token;
             //! String that is used to test against the login failed text
             static QString Test;
+            //! for RetrievePrivateConfig, if we should try to load from
+            bool loadOldConfig;
     };
 }
 


### PR DESCRIPTION
main reason is to not mess with Huggle 2' config, were they (hg2 and hg3) would override each other with loss of configuration options they self don't know about.

I may have missed some messages to alter to huggle3.css.

I have fundamentally tested this change and it works.
