### PR TITLE
reworked revert and warn buttons to have a more intuitive popup menu

### DIFF
--- a/huggle/mainwindow.cpp
+++ b/huggle/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include "mainwindow.hpp"
 #include <QDesktopServices>
 #include <QMessageBox>
+#include <QToolButton>
 #include "configuration.hpp"
 #include "reloginform.hpp"
 #include "generic.hpp"
@@ -133,9 +134,25 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
             connect(actiona, SIGNAL(triggered()), this, SLOT(CustomRevertWarn()));
             connect(actionb, SIGNAL(triggered()), this, SLOT(CustomWarn()));
         }
-        this->ui->actionWarn->setMenu(this->WarnMenu);
-        this->ui->actionRevert->setMenu(this->RevertSummaries);
-        this->ui->actionRevert_and_warn->setMenu(this->RevertWarn);
+        // replace abstract QAction with QToolButton to be able to set PopupMode
+        QToolButton* aW = new QToolButton(this->ui->mainToolBar);
+        QToolButton* aR = new QToolButton(this->ui->mainToolBar);
+        QToolButton* aRaW = new QToolButton(this->ui->mainToolBar);
+        aW->setDefaultAction(this->ui->actionWarn);
+        aR->setDefaultAction(this->ui->actionRevert);
+        aRaW->setDefaultAction(this->ui->actionRevert_and_warn);
+        aW->setMenu(this->WarnMenu);
+        aR->setMenu(this->RevertSummaries);
+        aRaW->setMenu(this->RevertWarn);
+        aW->setPopupMode(QToolButton::MenuButtonPopup);
+        aR->setPopupMode(QToolButton::MenuButtonPopup);
+        aRaW->setPopupMode(QToolButton::MenuButtonPopup);
+        this->ui->mainToolBar->insertWidget(this->ui->actionRevert_and_warn, aRaW);
+        this->ui->mainToolBar->insertWidget(this->ui->actionRevert_and_warn, aR);
+        this->ui->mainToolBar->insertWidget(this->ui->actionRevert_and_warn, aW);
+        this->ui->mainToolBar->removeAction(this->ui->actionWarn);
+        this->ui->mainToolBar->removeAction(this->ui->actionRevert);
+        this->ui->mainToolBar->removeAction(this->ui->actionRevert_and_warn);
     }
     this->tabifyDockWidget(this->SystemLog, this->Queries);
     this->GeneralTimer = new QTimer(this);


### PR DESCRIPTION
previously you have to hold the buttons to see the menu, now theres a clickable arrow at the side
