### PR TITLE
fixing double encoding

### DIFF
--- a/huggle/mainwindow.cpp
+++ b/huggle/mainwindow.cpp
@@ -1513,7 +1513,7 @@ void MainWindow::on_actionOpen_in_a_browser_triggered()
 {
     if (this->CurrentEdit != nullptr)
     {
-        QDesktopServices::openUrl(QString(Configuration::GetProjectWikiURL() + QUrl::toPercentEncoding(this->CurrentEdit->Page->PageName)));
+        QDesktopServices::openUrl(QString(Configuration::GetProjectWikiURL() + this->CurrentEdit->Page->PageName));
     }
 }
 


### PR DESCRIPTION
open in a browser encodes the page name twice - which gives invalid title.
removed 1 of the encodings
