### PR TITLE
Change the __isrtl__ message keyto isrtl

### DIFF
--- a/huggle/Localization/en.xml
+++ b/huggle/Localization/en.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resource>
     <string name="name">English</string>
-    <string name="__isrtl__">false</string>
+    <string name="isrtl">false</string>
     <string name="add">Add</string>
     <string name="apply">Apply</string>
     <string name="cancel">Cancel</string>

--- a/huggle/localization.cpp
+++ b/huggle/localization.cpp
@@ -98,7 +98,7 @@ Language *Localizations::MakeLanguageUsingXML(QString text, QString name)
             continue;
         }
         QString n_ = item.attribute("name");
-        if (n_ == "__isrtl__")
+        if (n_ == "isrtl")
         {
             l->IsRTL = Configuration::SafeBool(item.text());
             continue;


### PR DESCRIPTION
A message key with such underscores is problematic for translatewiki.
Because translatewiki is a wiki, and message keys are page title,
underscores are handled in a tricky way, so it's better not to have them
in messages.
