### PR TITLE
RTL support for huggle: proper layout direction

### DIFF
--- a/huggle/Localization/ar.xml
+++ b/huggle/Localization/ar.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="name">Arabic</string>
+  <string name="isrtl">true</string>
   <string name="add">أضف</string>
   <string name="apply">طبِّق</string>
   <string name="cancel">ألغِ</string>

--- a/huggle/Localization/fa.xml
+++ b/huggle/Localization/fa.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="name">Persian</string>
+  <string name="isrtl">true</string>
   <string name="add">افزودن</string>
   <string name="apply">اعمال‌کردن</string>
   <string name="cancel">لغو</string>

--- a/huggle/Localization/he.xml
+++ b/huggle/Localization/he.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="name">עברית</string>
+  <string name="isrtl">true</string>
   <string name="add">הוספה</string>
   <string name="apply">החלה</string>
   <string name="cancel">ביטול</string>

--- a/huggle/Resources/html/RTL.css
+++ b/huggle/Resources/html/RTL.css
@@ -11,3 +11,7 @@ td.diff-deletedline {
 	text-align: right;
 	direction: rtl;
 }
+
+body {
+	direction: rtl;
+}

--- a/huggle/localization.cpp
+++ b/huggle/localization.cpp
@@ -286,6 +286,21 @@ QString Localizations::Localize(QString key, QString parameter)
     return Localize(key, list);
 }
 
+bool Localizations::IsRTL() {
+	bool rtl = false;
+	int c = 0;
+	while (c<this->LocalizationData.count())
+    {
+        if (this->LocalizationData.at(c)->LanguageName == this->PreferredLanguage)
+        {
+			Language *l = this->LocalizationData.at(c);
+			rtl = l->IsRTL;
+		}
+		c++;
+	}
+	return rtl;
+}
+
 Language::Language(QString name)
 {
     this->LanguageName = name;

--- a/huggle/localization.hpp
+++ b/huggle/localization.hpp
@@ -73,6 +73,9 @@ namespace Huggle
             QString Localize(QString key, QStringList parameters);
             QString Localize(QString key, QString parameter);
             QString Localize(QString key, QString par1, QString par2);
+			
+			//! Check whether the preferred language is RightToLeft language.
+			bool IsRTL();
             //! Languages
             QList<Language*> LocalizationData;
             //! Language selected by user this is only a language of interface

--- a/huggle/login.cpp
+++ b/huggle/login.cpp
@@ -122,6 +122,12 @@ void Login::Localize()
     this->ui->labelTranslate->setText(QString("<html><head/><body><p><a href=\"http://meta.wikimedia.org/wiki/Huggle/Localization\"><span style=\""\
                                               " text-decoration: underline; color:#0000ff;\">%1</span></a></p></body></html>")
                                               .arg(_l("login-translate")));
+
+	if (Localizations::HuggleLocalizations->IsRTL()) {
+		QApplication::setLayoutDirection(Qt::RightToLeft);
+	} else {
+		QApplication::setLayoutDirection(Qt::LeftToRight);
+	}
 }
 
 void Login::Update(QString ms)

--- a/huggle/mainwindow.cpp
+++ b/huggle/mainwindow.cpp
@@ -1600,6 +1600,12 @@ void MainWindow::Localize()
     this->ui->actionWarn_the_user->setText(_l("main-user-warn"));
     this->ui->actionOpen_in_a_browser->setText(_l("main-browser-open"));
     this->ui->actionDisplay_this_page->setText(_l("main-page-display"));
+
+	// arrows icons should be mirrored for RTL languages
+	if (Localizations::HuggleLocalizations->IsRTL()) {
+		this->ui->actionForward->setIcon(QIcon(":/huggle/pictures/Resources/browser-prev.png"));
+		this->ui->actionBack->setIcon(QIcon(":/huggle/pictures/Resources/browser-next.png"));
+	}
 }
 
 void MainWindow::_BlockUser()


### PR DESCRIPTION
- setting isrtl for Arabic, Hebrew and Persian (I know localization should be done in translatewiki but there is no such messages there yet ;) )
- utility function in Localization for checking whether the current language is RTL
- set layout direction for proper direction
- swapping the prev/forward icons in RTL languages (to be similar to browser)
