### PR TITLE
huggleweb.cpp: Use red colour for summaries

### DIFF
--- a/huggle/huggleweb.cpp
+++ b/huggle/huggleweb.cpp
@@ -164,10 +164,10 @@ void HuggleWeb::DisplayDiff(WikiEdit *edit)
     }
     if (edit->Summary.isEmpty())
     {
-        Summary = "<font color=red> " + _l("browser-miss-summ") + "</font>";
+        Summary = _l("browser-miss-summ");
     } else
     {
-        Summary = Encode(edit->Summary);
+        Summary = "<font color=red> " + Encode(edit->Summary) + "</font>";
     }
     Summary += "<b> Size change: " + size + "</b>";
     HTML += "<b>" + _l("summary") + ":</b> " + Summary +


### PR DESCRIPTION
This commit changes the colour of summaries to red, and blank summary placeholder to black.
Patrollers sometimes go too fast when patrolling, ignoring edit summaries which may justify the blanking/suspicious edits.
In conclusion, we need to notify the patrollers when an edit /has/ a summary, not when it doesn't.
