### PR TITLE
Update README.md after Bugzilla→Phabricator migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ sanity check, like documentation or comments, please append [ci skip] to your me
 
 Reporting bugs
 ===============
-Please use https://bugzilla.wikimedia.org/enter_bug.cgi?product=Huggle or https://phabricator.wikimedia.org/maniphest/task/create/?projects=Huggle
+Please use https://phabricator.wikimedia.org/maniphest/task/create/?projects=Huggle
 
 License
 ===============


### PR DESCRIPTION
https://bugzilla.wikimedia.org/enter_bug.cgi?product=Huggle
redirects to:
https://phabricator.wikimedia.org
