### PR TITLE
Move CSRF token obtaining code to login.cpp

### DIFF
--- a/huggle/blockuser.hpp
+++ b/huggle/blockuser.hpp
@@ -38,8 +38,7 @@ namespace Huggle
             explicit BlockUser(QWidget *parent = nullptr);
             ~BlockUser();
             void SetWikiUser(WikiUser *User);
-            void CheckToken();
-            void GetToken();
+            void SendBlockRequest();
             void Failed(QString reason);
             void Block();
             void sendBlockNotice(ApiQuery *dependency);
@@ -56,8 +55,6 @@ namespace Huggle
             WikiUser *user;
             //! Query to exec api to block user
             Collectable_SmartPtr<ApiQuery> qUser;
-            Collectable_SmartPtr<ApiQuery> qTokenApi;
-            QString BlockToken;
             int QueryPhase;
     };
 }

--- a/huggle/deleteform.hpp
+++ b/huggle/deleteform.hpp
@@ -44,19 +44,14 @@ namespace Huggle
             void on_pushButton_2_clicked();
             void OnTick();
         private:
-            void GetToken();
             void Delete();
-            void CheckDeleteToken();
+            void SendDeleteRequest();
             void Failed(QString Reason);
             Ui::DeleteForm *ui;
             WikiPage *page;
-            QString DeleteToken;
-            QString DeleteToken2;
             //! Query used to execute delete of a page
             Collectable_SmartPtr<ApiQuery> qDelete;
             Collectable_SmartPtr<ApiQuery> qTalk;
-            //! This is used to retrieve a token
-            Collectable_SmartPtr<ApiQuery> qToken;
             //! Set the page to delete
             QTimer *tDelete;
             WikiPage *TalkPage;

--- a/huggle/editquery.hpp
+++ b/huggle/editquery.hpp
@@ -54,9 +54,7 @@ namespace Huggle
             bool Minor;
         private:
             void EditPage();
-            QString Token;
             QString OriginalText = "";
-            Collectable_SmartPtr<ApiQuery> qToken;
             Collectable_SmartPtr<ApiQuery> qRetrieve;
             bool HasPreviousPageText = false;
             //! Api query to edit page

--- a/huggle/login.cpp
+++ b/huggle/login.cpp
@@ -515,7 +515,7 @@ void Login::FinishLogin(WikiSite *site)
         qr = new ApiQuery(ActionQuery, site);
         this->qTokenInfo.insert(site, qr);
         qr->IncRef();
-        qr->Parameters = "meta=tokens&type=" + QUrl::toPercentEncoding("watch|patrol|rollback");
+        qr->Parameters = "meta=tokens&type=" + QUrl::toPercentEncoding("csrf|watch|patrol|rollback");
         qr->Process();
         this->Statuses[site] = RetrievingProjectConfig;
     }
@@ -859,6 +859,15 @@ void Login::ProcessSiteInfo(WikiSite *site)
                 } else
                 {
                     HUGGLE_DEBUG1("No rollback for " + site->Name + "result: " + this->qTokenInfo[site]->Result->Data);
+                }
+
+                if (tokens->Attributes.contains("csrftoken"))
+                {
+                    site->GetProjectConfig()->CSRFToken = tokens->GetAttribute("csrftoken");
+                    HUGGLE_DEBUG("CSRF token for " + site->Name + ": " + site->GetProjectConfig()->RollbackToken, 2);
+                } else
+                {
+                    HUGGLE_DEBUG1("No CSRF token for " + site->Name + ", result: " + this->qTokenInfo[site]->Result->Data);
                 }
             }
         } else

--- a/huggle/message.hpp
+++ b/huggle/message.hpp
@@ -28,7 +28,6 @@ namespace Huggle
         MessageStatus_None,
         MessageStatus_Done,
         MessageStatus_Failed,
-        MessageStatus_RetrievingToken,
         MessageStatus_RetrievingTalkPage,
         MessageStatus_SendingMessage
     };
@@ -50,7 +49,6 @@ namespace Huggle
             //! Creates a new instance of message class that is used to deliver a message to users
             Message(WikiUser *target, QString MessageText, QString MessageSummary);
             ~Message();
-            void RetrieveToken();
             //! Send a message to user
             void Send();
             //! Returns true in case that message was sent
@@ -91,13 +89,8 @@ namespace Huggle
             //! This is a generic finish that either finishes whole message sending, or call respective finish function
             //! that is needed to finish the current step
             void Finish();
-            //! Finish parsing the token
-            bool FinishToken();
             //! Returns true if there is a valid token in memory
 
-            //! Valid token means that it is syntactically correct, not that it isn't expired
-            bool HasValidEditToken();
-            bool RetrievingToken();
             bool IsSending();
             //! This function perform several checks and if everything is ok, it automatically calls next functions that send the message
             void PreflightCheck();
@@ -107,7 +100,6 @@ namespace Huggle
             void ProcessSend();
             void ProcessTalk();
             QString Append(QString text, QString OriginalText, QString Label);
-            Collectable_SmartPtr<ApiQuery> qToken;
             Collectable_SmartPtr<ApiQuery> query;
             //! This is a text of talk page that was present before we change it
             QString Page;

--- a/huggle/projectconfiguration.hpp
+++ b/huggle/projectconfiguration.hpp
@@ -74,7 +74,7 @@ namespace Huggle
             QString ApprovalPage = "Project:Huggle/Users";
             QString ProjectName;
             WikiSite    *Site = nullptr;
-            QString     EditToken = "";
+            QString     CSRFToken = "";
             QStringList Months;
             //! Pointer to AIV page
             WikiPage    *AIVP = nullptr;

--- a/huggle/protectpage.hpp
+++ b/huggle/protectpage.hpp
@@ -52,11 +52,7 @@ namespace Huggle
         private:
             void Failed(QString reason);
             void Protect();
-            void getTokenToProtect();
-            void checkTokenToProtect();
-            QString ProtectToken;
-            //! Pointer to get first token
-            Collectable_SmartPtr<ApiQuery> qToken;
+            void sendProtectRequest();
             //! Pointer for	protection
             Collectable_SmartPtr<ApiQuery> qProtection;
             Ui::ProtectPage *ui;


### PR DESCRIPTION
The token used in various queries is now taken from project configuration.
Follow-ups #126.

I know that the GCI task is closed already, but I improved it as you, @benapetr, mentioned. It looks that obtaining CSRF token once, at login actually works. :)
