### PR TITLE
enable AA_UseHighDpiPixmaps for HiDPI support

### DIFF
--- a/huggle/main.cpp
+++ b/huggle/main.cpp
@@ -68,6 +68,10 @@ int main(int argc, char *argv[])
         Huggle::HgApplication a(argc, argv);
         QApplication::setApplicationName("Huggle");
         QApplication::setOrganizationName("Wikimedia");
+        #if QT_VERSION >= 0x050100
+            // enable HiDPI support (available since Qt 5.1, but off by default)
+            a.setAttribute(Qt::AA_UseHighDpiPixmaps);
+        #endif
         Huggle::Configuration::HuggleConfiguration = new Huggle::Configuration();
         // check if arguments don't need to exit program
         if (!TerminalParse(parser))


### PR DESCRIPTION
Enable AA_UseHighDpiPixmaps for HiDPI support per [Qt Blog](http://blog.qt.io/blog/2013/04/25/retina-display-support-for-mac-os-ios-and-x11/). 
Apparently the toolbar icons are already high-res enough: 
![toolbar_compare](https://cloud.githubusercontent.com/assets/1217894/8023097/bb3fe8ba-0caf-11e5-873e-f206baff6c20.png)