### PR TITLE
Improve the grammar of editquery-invalid-token

### DIFF
--- a/huggle/Localization/en.xml
+++ b/huggle/Localization/en.xml
@@ -640,7 +640,7 @@
   <string name="editquery-success">Successfully edit $1 on $2</string>
   <string name="editquery-token">Retrieving token to edit $1</string>
   <string name="editquery-token-error">Unable to retrieve edit token</string>
-  <string name="editquery-invalid-token">Unable to edit $1 because token I had in cache is no longer valid, please try to edit that page once more</string>
+  <string name="editquery-invalid-token">Unable to edit $1 because token I had in cache is no longer valid. Please try to edit that page once more</string>
   <string name="provider-failure">Failure of feed provider $1 on $2, trying to find some alternative provider</string>
   <string name="provider-primary-failure">Primary feed provider has failed, falling back to wiki provider</string>
   <string name="rc-error">Unable to retrieve data from wiki feed, last error: $1</string>


### PR DESCRIPTION
Sentences should be separated by full stop.