### PR TITLE
README.md: Add qtscript5-dev to the requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Libraries and tools you need to have to build:
 * C++11 compiler
 * [CMake](https://github.com/Kitware/CMake) 2.8.9 or higher is required
 * QT4 sdk (libqt4-dev libqt4-webkit libqt4-network qt4-qmake libqtwebkit-dev libqt4-dev-bin qt4-dev-tools)
-* (optional) QT5 sdk (libqt5webkit5-dev qt5-default qtquick1-5-dev qtlocation5-dev qtsensors5-dev qtdeclarative5-dev)
+* (optional) QT5 sdk (libqt5webkit5-dev qt5-default qtquick1-5-dev qtlocation5-dev qtsensors5-dev qtscript5-dev qtdeclarative5-dev)
 * (optional) Python (libpython-dev)
 
 Windows


### PR DESCRIPTION
`qtscript5-dev` seems to be required to build with Qt5. For the record, I'm using Debian stretch/testing.