### PR TITLE
Url encode login token

### DIFF
--- a/huggle/login.cpp
+++ b/huggle/login.cpp
@@ -474,7 +474,7 @@ void Login::PerformLoginPart2(WikiSite *site)
     query->IncRef();
     query->Parameters = "lgname=" + QUrl::toPercentEncoding(hcfg->SystemConfig_Username)
             + "&lgpassword=" + QUrl::toPercentEncoding(hcfg->TemporaryConfig_Password)
-            + "&lgtoken=" + token;
+            + "&lgtoken=" + QUrl::toPercentEncoding(token);
     query->UsingPOST = true;
     query->Process();
 }


### PR DESCRIPTION
Since MediaWiki 1.27.0-wmf.13, session tokens can include non-URL safe
characters.

Patch is prepared against the 3.1.18 tag to make getting a new build out easier.