### PR TITLE
Fix Travis-CI builds on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 # See ./travis/* for the actual scripts that get run
 
 language: cpp
+sudo: required
 
 env:
   - THENEEDFORTHIS=FAIL
@@ -20,11 +21,11 @@ matrix:
   exclude:
     - env: THENEEDFORTHIS=FAIL
 
-before_install: bash ./travis/before_install.sh
-install: bash ./travis/install.sh
+before_install: bash -x ./travis/before_install.sh
+install: bash -x ./travis/install.sh
 
-before_script: bash ./travis/before_script.sh
-script: bash ./travis/script.sh
+before_script: bash -x ./travis/before_script.sh
+script: bash -x ./travis/script.sh
 
 notifications: 
   irc: 

--- a/travis/before_script.sh
+++ b/travis/before_script.sh
@@ -2,9 +2,7 @@
 
 g++ --version
 
-cd /home/travis/build/huggle/huggle3-qt-lx/travis
-gunzip *.gz
-cd /home/travis/build/huggle/huggle3-qt-lx/huggle
+cd ./huggle
 
 if [ "$QTTYPE" = "4" ]; then
 	./configure --qt4 --extension

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-cd /home/travis/build/huggle/huggle3-qt-lx/huggle/tests/test
+cd ./huggle/tests/test
 
 echo Testing QTTYPE $QTTYPE
 


### PR DESCRIPTION
New forks will default to containers, where sudo must
be explicitly enabled.

Path `/home/travis/build/huggle` does not exist on forks,
so relative paths should be used.

Also use `bash -x` to show the steps being taken.