### PR TITLE
GCI: Incorporated 10 New Languages

### DIFF
--- a/huggle/TranslationStats/main.cpp
+++ b/huggle/TranslationStats/main.cpp
@@ -62,43 +62,52 @@ int main(int argc, char *argv[])
     Localizations::HuggleLocalizations->LocalInit("bg"); // Bulgarian
     //Localizations::HuggleLocalizations->LocalInit("bn"); // Bengali
     Localizations::HuggleLocalizations->LocalInit("br"); // Brezhoneg
+    Localizations::HuggleLocalizations->LocalInit("ca"); // Catalan
     Localizations::HuggleLocalizations->LocalInit("cz"); // Czech
+    Localizations::HuggleLocalizations->LocalInit("da"); // Danish
     Localizations::HuggleLocalizations->LocalInit("de"); // Deutsch
     Localizations::HuggleLocalizations->LocalInit("es"); // Spanish
     Localizations::HuggleLocalizations->LocalInit("fa"); // Persian
+    Localizations::HuggleLocalizations->LocalInit("fi"); // Finnish
+    Localizations::HuggleLocalizations->LocalInit("fj"); // Fijian
     Localizations::HuggleLocalizations->LocalInit("fr"); // French
-    Localizations::HuggleLocalizations->LocalInit("gu");
+    Localizations::HuggleLocalizations->LocalInit("gu"); // Gujarati
     Localizations::HuggleLocalizations->LocalInit("he"); // Hebrew
     Localizations::HuggleLocalizations->LocalInit("hi"); // Hindi
+    Localizations::HuggleLocalizations->LocalInit("hu"); // Hungarian
+    Localizations::HuggleLocalizations->LocalInit("id"); // Indonesian
     Localizations::HuggleLocalizations->LocalInit("it"); // Italian
     Localizations::HuggleLocalizations->LocalInit("ja"); // Japanese
-    Localizations::HuggleLocalizations->LocalInit("ka"); // ?
-    Localizations::HuggleLocalizations->LocalInit("kk-cyrl");
+    Localizations::HuggleLocalizations->LocalInit("ka"); // Georgian
+    Localizations::HuggleLocalizations->LocalInit("kk-cyrl"); // Kazakh (Cyrillic)
     //Localizations::HuggleLocalizations->LocalInit("km"); // Khmer
     Localizations::HuggleLocalizations->LocalInit("kn"); // Kannada
     Localizations::HuggleLocalizations->LocalInit("ko"); // Korean
-    Localizations::HuggleLocalizations->LocalInit("ksh");
+    Localizations::HuggleLocalizations->LocalInit("ksh"); // Kölsch
     Localizations::HuggleLocalizations->LocalInit("lb"); // Lebanon
-    Localizations::HuggleLocalizations->LocalInit("lt");
+    Localizations::HuggleLocalizations->LocalInit("lt"); // Lithuanian
     Localizations::HuggleLocalizations->LocalInit("mk"); // Macedonian
     Localizations::HuggleLocalizations->LocalInit("ml"); // Malayalam
     Localizations::HuggleLocalizations->LocalInit("mr"); // Marathi
-    Localizations::HuggleLocalizations->LocalInit("ms");
+    Localizations::HuggleLocalizations->LocalInit("ms"); // Malay
     Localizations::HuggleLocalizations->LocalInit("nl"); // Dutch
     Localizations::HuggleLocalizations->LocalInit("no"); // Norwegian
     Localizations::HuggleLocalizations->LocalInit("oc"); // Occitan
     Localizations::HuggleLocalizations->LocalInit("or"); // Oriya
-    Localizations::HuggleLocalizations->LocalInit("pl");
+    Localizations::HuggleLocalizations->LocalInit("pl"); // Polish
     Localizations::HuggleLocalizations->LocalInit("pt"); // Portuguese
     Localizations::HuggleLocalizations->LocalInit("pt-BR"); // Portuguese (in Brazil)
     Localizations::HuggleLocalizations->LocalInit("ru"); // Russian
-    Localizations::HuggleLocalizations->LocalInit("ro");` 
-    Localizations::HuggleLocalizations->LocalInit("sa");
+    Localizations::HuggleLocalizations->LocalInit("ro");`// Romanian
+    Localizations::HuggleLocalizations->LocalInit("sa"); // Sanskrit
+    Localizations::HuggleLocalizations->LocalInit("en"); // Serbian
     Localizations::HuggleLocalizations->LocalInit("sv"); // Swedish
-    Localizations::HuggleLocalizations->LocalInit("ta");
+    Localizations::HuggleLocalizations->LocalInit("ta"); // Tamil
+    Localizations::HuggleLocalizations->LocalInit("th"); // Thai
     Localizations::HuggleLocalizations->LocalInit("tr"); // Turkish
-    Localizations::HuggleLocalizations->LocalInit("ur");
-    Localizations::HuggleLocalizations->LocalInit("uk"); 
+    Localizations::HuggleLocalizations->LocalInit("ur"); // Urdu
+    Localizations::HuggleLocalizations->LocalInit("uk"); // Ukrainian
+    Localizations::HuggleLocalizations->LocalInit("uz"); // Uzbek
     Localizations::HuggleLocalizations->LocalInit("zh-hant"); // Chinese
     Localizations::HuggleLocalizations->LocalInit("zh"); // Chinese
     HTML();

--- a/huggle/TranslationStats/text.qrc
+++ b/huggle/TranslationStats/text.qrc
@@ -6,14 +6,20 @@
     <file>../Localization/bg.xml</file>
     <file>../Localization/bn.xml</file>
     <file>../Localization/br.xml</file>
+    <file>../Localization/ca.xml</file>
     <file>../Localization/cz.xml</file>
+    <file>../Localization/da.xml</file>
     <file>../Localization/de.xml</file>
     <file>../Localization/es.xml</file>
     <file>../Localization/fa.xml</file>
+    <file>../Localization/fi.xml</file>
+    <file>../Localization/fj.xml</file>
     <file>../Localization/fr.xml</file>
     <file>../Localization/gu.xml</file>
-    <file>../Localization/hi.xml</file>
     <file>../Localization/he.xml</file>
+    <file>../Localization/hi.xml</file>
+    <file>../Localization/hu.xml</file>
+    <file>../Localization/id.xml</file>
     <file>../Localization/it.xml</file>
     <file>../Localization/ja.xml</file>
     <file>../Localization/ka.xml</file>
@@ -36,13 +42,16 @@
     <file>../Localization/pt-BR.xml</file>
     <file>../Localization/pt.xml</file>
     <file>../Localization/sa.xml</file>
+    <file>../Localization/sr.xml</file>
     <file>../Localization/ro.xml</file>
     <file>../Localization/ru.xml</file>
     <file>../Localization/sv.xml</file>
     <file>../Localization/ta.xml</file>
+    <file>../Localization/th.xml</file>
     <file>../Localization/tr.xml</file>
     <file>../Localization/uk.xml</file>
     <file>../Localization/ur.xml</file>
+    <file>../Localization/uz.xml</file>
     <file>../Localization/zh.xml</file>
     <file>../Localization/zh-hant.xml</file>
   </qresource>


### PR DESCRIPTION
Added 10 new languages-
1. ca (Catalan)
2. da (Danish)
3. fi (Finnish)
4. fj (Fijian)
5. hr (Croatian)
6. hu (Hungarian)
7. id (Indonesian)
8. sr (Serbian)
9. th (Thai)
10. sr (Serbian)

And Commented the languages name which aren't commented.