### PR TITLE
Fix removal of whitespace in ignored/required tags

### DIFF
--- a/huggle/hugglequeuefilter.cpp
+++ b/huggle/hugglequeuefilter.cpp
@@ -204,7 +204,10 @@ void HuggleQueueFilter::SetIgnoredTags_CommaSeparated(QString list)
     QList<QString> tags = list.split(",");
     foreach(QString x, tags)
     {
-        x = x.replace(" ", "").replace("\n", "");
+        if (x.at(0) == QLatin1Char(' ')) {
+            x = x.mid(1, x.length() - 1);
+        }
+        x = x.replace("\n", "");
         if (!x.isEmpty())
         {
             // only use tags that contain something
@@ -219,7 +222,10 @@ void HuggleQueueFilter::SetRequiredTags_CommaSeparated(QString list)
     QList<QString> tags = list.split(",");
     foreach(QString x, tags)
     {
-        x = x.replace(" ", "").replace("\n", "");
+        if (x.at(0) == QLatin1Char(' ')) {
+            x = x.mid(1, x.length() - 1);
+        }
+        x = x.replace("\n", "");
         if (!x.isEmpty())
         {
             // only use tags that contain something


### PR DESCRIPTION
This replacement was presumably to handle spaces following commas, but it also got important spaces in the middle of tags.

Bug: T155333