### PR TITLE
implemented report mode

### DIFF
--- a/huggle/mainwindow.cpp
+++ b/huggle/mainwindow.cpp
@@ -1055,7 +1055,7 @@ bool MainWindow::Warn(QString WarningType, RevertQuery *dependency, WikiEdit *re
     PendingWarning *ptr_Warning_ = Warnings::WarnUser(WarningType, dependency, related_edit, &Report_);
     if (Report_)
     {
-        if (hcfg->UserConfig->AutomaticReports)
+        if ((hcfg->UserConfig->AutomaticReports && related_edit->GetSite()->GetProjectConfig()->ReportMode != ReportType_StrictManual) || related_edit->GetSite()->GetProjectConfig()->ReportMode == ReportType_StrictAuto)
         {
             ReportUser::SilentReport(related_edit->User);
         } else

--- a/huggle/projectconfiguration.cpp
+++ b/huggle/projectconfiguration.cpp
@@ -618,6 +618,25 @@ bool ProjectConfiguration::ParseYAML(QString yaml_src, QString *reason, WikiSite
     this->SpeedyWarningSummary = HuggleParser::YAML2String("speedy-message-summary", yaml, "Notification: [[$1]] has been listed for deletion");
     this->Patrolling = HuggleParser::YAML2Bool("patrolling-enabled", yaml);
     this->PatrollingFlaggedRevs = HuggleParser::YAML2Bool("patrolling-flaggedrevs", yaml, false);
+    // Get report mode
+    QString report = HuggleParser::YAML2String("report", yaml);
+    if (report.isEmpty())
+    {
+        HUGGLE_WARNING("Project " + this->Site->Name + " doesn't contain report mode (report), falling back to default");
+    } else
+    {
+        report = report.toLower();
+        if (report == "defaultauto")
+            this->ReportMode = ReportType_DefaultAuto;
+        else if (report == "strictauto")
+            this->ReportMode = ReportType_StrictAuto;
+        else if (report == "strictmanual")
+            this->ReportMode = ReportType_StrictManual;
+        else if (report == "defaultmanual")
+            this->ReportMode = ReportType_DefaultManual;
+        else
+            HUGGLE_WARNING("Uknown report mode, falling back to default");
+    }
     this->ReportSummary = HuggleParser::YAML2String("report-summary", yaml);
     this->ReportAutoSummary = HuggleParser::YAML2String("report-auto-summary", yaml, "This user was automatically reported by Huggle due to reverted vandalism after four warnings, please verify their"\
                                                                                               " contributions carefully, it may be a false positive");

--- a/huggle/projectconfiguration.hpp
+++ b/huggle/projectconfiguration.hpp
@@ -44,6 +44,14 @@ namespace Huggle
         HeadingsNone
     };
 
+    enum ReportType
+    {
+        ReportType_DefaultManual,
+        ReportType_DefaultAuto,
+        ReportType_StrictManual,
+        ReportType_StrictAuto
+    };
+
     /*!
      * \brief The ScoreWord class
      *
@@ -125,6 +133,7 @@ namespace Huggle
             QString         RFPP_Mark = "";
             QString         RFPP_Regex = "";
             QString         RFPP_Page = "";
+            ReportType      ReportMode = ReportType_DefaultAuto;
             QString         ReportAIV = "";
             QString         Feedback = "";
             //! Section of report page to append template to
@@ -194,6 +203,7 @@ namespace Huggle
             //! Data of wl (list of users)
             QStringList     WhiteList;
             QStringList     NewWhitelist;
+
             QString         ReportSummary;
             QString         RestoreSummary = "Restored revision $1 made by $2";
             bool            WelcomeGood = true;

--- a/huggle/warninglist.cpp
+++ b/huggle/warninglist.cpp
@@ -74,7 +74,7 @@ void WarningList::on_pushButton_clicked()
     PendingWarning *ptr_Warning_ = Warnings::WarnUser(wt, nullptr, this->wikiEdit, &Report_);
     if (Report_)
     {
-        if (hcfg->UserConfig->AutomaticReports)
+        if ((hcfg->UserConfig->AutomaticReports && this->wikiEdit->GetSite()->GetProjectConfig()->ReportMode != ReportType_StrictManual) || this->wikiEdit->GetSite()->GetProjectConfig()->ReportMode == ReportType_StrictAuto)
         {
             ReportUser::SilentReport(this->wikiEdit->User);
         } else


### PR DESCRIPTION
we used to have this in old huggle but now we also store this option in
user config, so I made 4 options (while in fact only 2 of them really
work now) to let project config maintainers override the user
preference.

This basically adds back the "report" option in config