### PR TITLE
David moreno72 patch 1

### DIFF
--- a/huggle/generic.cpp
+++ b/huggle/generic.cpp
@@ -176,16 +176,7 @@ QString Generic::EvaluateWikiPageContents(ApiQuery *query, bool *failed, QString
     {
         if (reason) { *reason = EvaluatePageErrorReason_Unknown; }
         *failed = true;
-        QString errorMessage;
-        if (query->Result != 0)
-        {
-            errorMessage = query->Result->ErrorMessage;
-        }
-        else
-        {
-            errorMessage = "Unknown error";
-        }
-        return errorMessage;
+        return "Unknown error";
     }
     ApiQueryResultNode *rev = query->GetApiQueryResult()->GetNode("rev");
     ApiQueryResultNode *page = query->GetApiQueryResult()->GetNode("page");

--- a/huggle/generic.cpp
+++ b/huggle/generic.cpp
@@ -176,7 +176,16 @@ QString Generic::EvaluateWikiPageContents(ApiQuery *query, bool *failed, QString
     {
         if (reason) { *reason = EvaluatePageErrorReason_Unknown; }
         *failed = true;
-        return query->Result->ErrorMessage;
+        QString errorMessage;
+        if (query->Result != 0)
+        {
+            errorMessage = query->Result->ErrorMessage;
+        }
+        else
+        {
+            errorMessage = "Unknown error";
+        }
+        return errorMessage;
     }
     ApiQueryResultNode *rev = query->GetApiQueryResult()->GetNode("rev");
     ApiQueryResultNode *page = query->GetApiQueryResult()->GetNode("page");

--- a/huggle/userinfoform.cpp
+++ b/huggle/userinfoform.cpp
@@ -132,6 +132,13 @@ void UserinfoForm::OnTick()
     }
     if (this->qContributions->IsProcessed())
     {
+        if (this->qContributions->Result == 0)
+        {
+            Syslog::HuggleLogs->ErrorLog("user-history-fail");
+            this->timer->stop();
+            this->qContributions.Delete();
+            return;
+        }
         if (this->qContributions->Result->IsFailed())
         {
             Syslog::HuggleLogs->ErrorLog(_l("user-history-fail", this->User->Username));

--- a/huggle/wikiedit.cpp
+++ b/huggle/wikiedit.cpp
@@ -274,7 +274,7 @@ bool WikiEdit::FinalizePostProcessing()
         if (this->qDifference->IsFailed())
         {
             // whoa it ended in error, we need to get rid of this edit somehow now
-            Huggle::Syslog::HuggleLogs->WarningLog("Failed to obtain diff for " + this->Page->PageName + " the error was: Unknown error");
+            Huggle::Syslog::HuggleLogs->WarningLog("Failed to obtain diff for " + this->Page->PageName + " the error was: " + this->qDifference->Result->ErrorMessage);
             this->qDifference = nullptr;
             this->PostProcessing = false;
             return true;
@@ -323,8 +323,7 @@ bool WikiEdit::FinalizePostProcessing()
             this->DiffText = temp->Value;
         } else
         {
-            Huggle::Syslog::HuggleLogs->WarningLog("Failed to obtain diff for " + this->Page->PageName + " the error was: "
-                                                 + this->qDifference->Result->Data);
+            Huggle::Syslog::HuggleLogs->WarningLog("Failed to obtain diff for " + this->Page->PageName + " the error was: " + this->qDifference->Result->ErrorMessage);
         }
         this->qDifference = nullptr;
         // we are done processing the diff

--- a/huggle/wikiedit.cpp
+++ b/huggle/wikiedit.cpp
@@ -274,8 +274,7 @@ bool WikiEdit::FinalizePostProcessing()
         if (this->qDifference->IsFailed())
         {
             // whoa it ended in error, we need to get rid of this edit somehow now
-            Huggle::Syslog::HuggleLogs->WarningLog("Failed to obtain diff for " + this->Page->PageName + " the error was: "
-                                                   + this->qDifference->Result->Data);
+            Huggle::Syslog::HuggleLogs->WarningLog("Failed to obtain diff for " + this->Page->PageName + " the error was: Unknown error");
             this->qDifference = nullptr;
             this->PostProcessing = false;
             return true;

--- a/huggle/wikiedit.cpp
+++ b/huggle/wikiedit.cpp
@@ -274,7 +274,7 @@ bool WikiEdit::FinalizePostProcessing()
         if (this->qDifference->IsFailed())
         {
             // whoa it ended in error, we need to get rid of this edit somehow now
-            Huggle::Syslog::HuggleLogs->WarningLog("Failed to obtain diff for " + this->Page->PageName + " the error was: " + this->qDifference->Result->ErrorMessage);
+            Huggle::Syslog::HuggleLogs->WarningLog("Failed to obtain diff for " + this->Page->PageName + " the error was: Unknown error");
             this->qDifference = nullptr;
             this->PostProcessing = false;
             return true;


### PR DESCRIPTION
It is annoying how often Huggle crashes, so I have been running the application with QT Creator and Eclipse Oxygen in debug mode. This has enabled me to track down the lines of code that are causing trouble. The main reason for the crashes has been the way errors are handled. In huggle/generic.cpp for example, query->Result can end up being a 0, and so a call to ErrorMessage will crash it. The same happens with huggle/userinfoform.cpp and huggle/wikiedit.cpp where this->qContributions and this->qDifference can end up being a 0. This needs to be fixed,