### PR TITLE
implemented auto-refresh

### DIFF
--- a/huggle/Localization/en.xml
+++ b/huggle/Localization/en.xml
@@ -165,6 +165,7 @@
   <string name="config-autoadvance">After reverting, move to next edit in the queue</string>
   <string name="config-userollback">Use rollback if available</string>
   <string name="config-revertsummaries">Revert summaries available in menu</string>
+  <string name="config-auto-refresh">Automatically refresh page in case there was another edit made to it</string>
   <string name="config-extendreports">Extend reports after additional vandalism</string>
   <string name="config-autoreport">When asked to warn a user with a final warning</string>
   <string name="config-reportnone">Do nothing</string>

--- a/huggle/huggletool.cpp
+++ b/huggle/huggletool.cpp
@@ -114,7 +114,7 @@ WikiSite *HuggleTool::GetSite()
     return Configuration::HuggleConfiguration->Projects.at(this->ui->comboBox->currentIndex());
 }
 
-void HuggleTool::RenderEdit()
+void HuggleTool::DownloadEdit()
 {
     if (!this->ui->pushButton->isEnabled() || !this->ui->lineEdit_3->text().length())
         return;
@@ -134,7 +134,7 @@ void HuggleTool::RenderEdit()
 
 void Huggle::HuggleTool::on_pushButton_clicked()
 {
-    this->RenderEdit();
+    this->DownloadEdit();
 }
 
 void HuggleTool::onTick()
@@ -237,7 +237,7 @@ QString HuggleTool::GenerateColor(QString color)
 
 void Huggle::HuggleTool::on_lineEdit_3_returnPressed()
 {
-    this->RenderEdit();
+    this->DownloadEdit();
 }
 
 void Huggle::HuggleTool::on_lineEdit_2_returnPressed()

--- a/huggle/huggletool.hpp
+++ b/huggle/huggletool.hpp
@@ -45,7 +45,7 @@ namespace Huggle
             void SetUser(QString user);
             void SetPage(WikiPage* page);
             WikiSite *GetSite();
-            void RenderEdit();
+            void DownloadEdit();
 
         private slots:
             void on_pushButton_clicked();

--- a/huggle/mainwindow.cpp
+++ b/huggle/mainwindow.cpp
@@ -2084,6 +2084,15 @@ WikiSite *MainWindow::GetCurrentWikiSite()
     return this->CurrentEdit->GetSite();
 }
 
+void MainWindow::RefreshPage()
+{
+    if (!this->CheckExit() || this->CurrentEdit == nullptr)
+        return;
+
+    this->tb->SetPage(this->CurrentEdit->Page);
+    this->tb->RenderEdit();
+}
+
 void MainWindow::LockPage()
 {
     this->EnableEditing(false);
@@ -3254,9 +3263,5 @@ void Huggle::MainWindow::on_actionRevert_edit_using_custom_reason_triggered()
 
 void Huggle::MainWindow::on_actionRefresh_triggered()
 {
-    if (!this->CheckExit() || this->CurrentEdit == nullptr)
-        return;
-
-    this->tb->SetPage(this->CurrentEdit->Page);
-    this->tb->RenderEdit();
+    this->RefreshPage();
 }

--- a/huggle/mainwindow.cpp
+++ b/huggle/mainwindow.cpp
@@ -1349,7 +1349,7 @@ void MainWindow::OnMainTimerTick()
     if (this->OnNext_EvPage != nullptr && this->qNext != nullptr && this->qNext->IsProcessed())
     {
         this->tb->SetPage(this->OnNext_EvPage);
-        this->tb->RenderEdit();
+        this->tb->DownloadEdit();
         delete this->OnNext_EvPage;
         this->OnNext_EvPage = nullptr;
         this->qNext = nullptr;
@@ -2071,7 +2071,7 @@ void MainWindow::RenderPage(QString Page)
     page->Site = this->GetCurrentWikiSite();
     this->tb->SetPage(page);
     delete page;
-    this->tb->RenderEdit();
+    this->tb->DownloadEdit();
 }
 
 WikiSite *MainWindow::GetCurrentWikiSite()
@@ -2090,7 +2090,7 @@ void MainWindow::RefreshPage()
         return;
 
     this->tb->SetPage(this->CurrentEdit->Page);
-    this->tb->RenderEdit();
+    this->tb->DownloadEdit();
 }
 
 void MainWindow::LockPage()

--- a/huggle/mainwindow.hpp
+++ b/huggle/mainwindow.hpp
@@ -160,6 +160,7 @@ namespace Huggle
             //! Try to load a page
             void RenderPage(QString Page);
             WikiSite *GetCurrentWikiSite();
+            void RefreshPage();
             //! Make currently displayed page unchangeable (useful when you render non-diff pages where rollback wouldn't work)
             void LockPage();
             //! List of edits that are being saved

--- a/huggle/preferences.cpp
+++ b/huggle/preferences.cpp
@@ -197,6 +197,7 @@ Preferences::Preferences(QWidget *parent) : HW("preferences", this, parent), ui(
     this->ui->cbCatScansAndWatched->setText(_l("preferences-performance-catscansandwatched"));
     this->ui->cbMaxScore->setText(_l("preferences-max-score"));
     this->ui->cbMinScore->setText(_l("preferences-min-score"));
+    this->ui->cb_AutoRefresh->setText(_l("config-auto-refresh"));
     this->ui->l_QueueSize->setText(_l("preferences-queue-size"));
     this->ui->l_EmptyQueuePage->setText(_l("preferences-empty-queue-page"));
 
@@ -342,6 +343,7 @@ void Huggle::Preferences::on_pushButton_2_clicked()
     hcfg->UserConfig->EnableMaxScore = this->ui->cbMaxScore->isChecked();
     hcfg->SystemConfig_QueueSize = this->ui->le_QueueSize->text().toInt();
     hcfg->UserConfig->PageEmptyQueue = this->ui->le_EmptyQueuePage->text();
+    hcfg->UserConfig->AutomaticRefresh = this->ui->cb_AutoRefresh->isChecked();
     if (hcfg->SystemConfig_QueueSize < 10)
         hcfg->SystemConfig_QueueSize = 10;
     hcfg->SystemConfig_PlaySoundOnIRCUserMsg = this->ui->cbPlayOnIRCMsg->isChecked();
@@ -803,6 +805,7 @@ void Preferences::ResetItems()
     this->ui->cbPlayOnNewItem->setChecked(hcfg->SystemConfig_PlaySoundOnQueue);
     this->ui->cbPlayOnIRCMsg->setChecked(hcfg->SystemConfig_PlaySoundOnIRCUserMsg);
     this->ui->cbCatScansAndWatched->setChecked(hcfg->SystemConfig_CatScansAndWatched);
+    this->ui->cb_AutoRefresh->setChecked(hcfg->UserConfig->AutomaticRefresh);
 #ifdef HUGGLE_NOAUDIO
     this->ui->ln_QueueSoundMinScore->setEnabled(false);
     this->ui->cbPlayOnNewItem->setEnabled(false);

--- a/huggle/preferences.ui
+++ b/huggle/preferences.ui
@@ -344,6 +344,13 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="cb_AutoRefresh">
+           <property name="text">
+            <string>Automatically refresh current page in case there was another edit made to it</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <layout class="QHBoxLayout" name="horizontalLayout_9">
            <item>
             <widget class="QLabel" name="label_14">

--- a/huggle/querypool.cpp
+++ b/huggle/querypool.cpp
@@ -119,6 +119,9 @@ void QueryPool::PreProcessEdit(WikiEdit *edit)
     if (hcfg->UserConfig->RemoveAfterTrustedEdit && edit->User->IsWhitelisted() &&
         MainWindow::HuggleMain && MainWindow::HuggleMain->Queue1)
         MainWindow::HuggleMain->Queue1->DeleteOlder(edit);
+    // In case we are currently looking at this page in main window, let's refresh
+    if (hcfg->UserConfig->AutomaticRefresh && MainWindow::HuggleMain->CurrentEdit != nullptr && edit->Page->PageName == MainWindow::HuggleMain->CurrentEdit->Page->PageName)
+        MainWindow::HuggleMain->RefreshPage();
 #endif
     edit->Status = StatusProcessed;
 }

--- a/huggle/userconfiguration.cpp
+++ b/huggle/userconfiguration.cpp
@@ -190,6 +190,7 @@ QString UserConfiguration::MakeLocalUserConfig(ProjectConfiguration *Project)
     configuration_ += "MaxScore:" + QString::number(this->MaxScore) + "\n";
     configuration_ += "EnableMinScore:" + Bool2String(this->EnableMinScore) + "\n";
     configuration_ += "MinScore:" + QString::number(this->MinScore) + "\n";
+    configuration_ += "AutomaticRefresh:" + Bool2String(this->AutomaticRefresh) + "\n";
     // shortcuts
     QStringList shortcuts = Configuration::HuggleConfiguration->Shortcuts.keys();
     // we need to do this otherwise huggle may sort the items differently every time and spam wiki
@@ -376,6 +377,7 @@ bool UserConfiguration::ParseUserConfig(QString config, ProjectConfiguration *Pr
     this->MinScore = ConfigurationParse("MinScore", config, "0").toLongLong();
     this->MaxScore = ConfigurationParse("MaxScore", config, "0").toLongLong();
     this->EnableMinScore = SafeBool(ConfigurationParse("EnableMinScore", config));
+    this->AutomaticRefresh = SafeBool(ConfigurationParse("AutomaticRefresh", config), this->AutomaticRefresh);
     // for now we do this only for home wiki but later we need to make it for every wiki
     if (IsHome)
     {

--- a/huggle/userconfiguration.hpp
+++ b/huggle/userconfiguration.hpp
@@ -80,6 +80,7 @@ namespace Huggle
             bool            AutomaticReports = false;
             //! Resolve edit conflict without asking user
             bool            AutomaticallyResolveConflicts = true;
+            bool            AutomaticRefresh = true;
             //! default-summary inherited from project config so there is no default here
             QString         DefaultSummary;
             QString         RollbackSummary;


### PR DESCRIPTION
So that if we are looking on some edit and there was a new edit done to
that very page we are looking at, it automatically reloads to top
revision. This is exactly how it worked in Huggle 2x and we kinda forgot
to implement this. It's optional but enabled by default.