### PR TITLE
fix travis

### DIFF
--- a/huggle/apiqueryresult.cpp
+++ b/huggle/apiqueryresult.cpp
@@ -9,10 +9,10 @@
 //GNU General Public License for more details.
 
 #include "apiqueryresult.hpp"
+#include <QtXml>
 #include "configuration.hpp"
 #include "exception.hpp"
 #include "syslog.hpp"
-#include <QtXml>
 
 using namespace Huggle;
 

--- a/huggle/core.cpp
+++ b/huggle/core.cpp
@@ -9,6 +9,9 @@
 //GNU General Public License for more details.
 
 #include "core.hpp"
+#include <QtXml>
+#include <QFile>
+#include <QPluginLoader>
 #include "configuration.hpp"
 #include "exception.hpp"
 #include "exceptionwindow.hpp"
@@ -33,9 +36,6 @@
 #include "wikipage.hpp"
 #include "wikisite.hpp"
 #include "wikiuser.hpp"
-#include <QtXml>
-#include <QFile>
-#include <QPluginLoader>
 
 using namespace Huggle;
 

--- a/huggle/editquery.cpp
+++ b/huggle/editquery.cpp
@@ -9,6 +9,7 @@
 //GNU General Public License for more details.
 
 #include "editquery.hpp"
+#include <QUrl>
 #include "apiqueryresult.hpp"
 #include "configuration.hpp"
 #include "exception.hpp"
@@ -23,7 +24,6 @@
 #include "wikipage.hpp"
 #include "wikiutil.hpp"
 #include "wikisite.hpp"
-#include <QUrl>
 
 using namespace Huggle;
 

--- a/huggle/localization.cpp
+++ b/huggle/localization.cpp
@@ -8,9 +8,12 @@
 //MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //GNU General Public License for more details.
 
-#include "localization.hpp"
+#include "definitions.hpp"
 #include <QtXml>
 #include <QFile>
+// localizations.hpp must be included after global headers
+// there is some collision in _l macro on OSX
+#include "localization.hpp"
 #include "exception.hpp"
 #include "configuration.hpp"
 #include "generic.hpp"

--- a/huggle/preferences.cpp
+++ b/huggle/preferences.cpp
@@ -9,6 +9,12 @@
 //GNU General Public License for more details.
 
 #include "preferences.hpp"
+#include <QMessageBox>
+#include <QLabel>
+#include <QSpinBox>
+#include <QFile>
+#include <QDir>
+#include <QMenu>
 #include "core.hpp"
 #include "configuration.hpp"
 #include "exception.hpp"
@@ -21,12 +27,6 @@
 #include "resources.hpp"
 #include "mainwindow.hpp"
 #include "ui_preferences.h"
-#include <QMessageBox>
-#include <QLabel>
-#include <QSpinBox>
-#include <QFile>
-#include <QDir>
-#include <QMenu>
 
 using namespace Huggle;
 

--- a/huggle/processlist.cpp
+++ b/huggle/processlist.cpp
@@ -8,15 +8,15 @@
 //MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //GNU General Public License for more details.
 
+#include "processlist.hpp"
+#include <QMenu>
+#include <QClipboard>
 #include "exception.hpp"
 #include "core.hpp"
 #include "configuration.hpp"
 #include "localization.hpp"
 #include "huggleprofiler.hpp"
-#include "processlist.hpp"
 #include "ui_processlist.h"
-#include <QMenu>
-#include <QClipboard>
 
 using namespace Huggle;
 

--- a/huggle/query.cpp
+++ b/huggle/query.cpp
@@ -8,11 +8,11 @@
 //MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //GNU General Public License for more details.
 
+#include "query.hpp"
+#include <QNetworkAccessManager>
 #include "exception.hpp"
 #include "gc.hpp"
 #include "syslog.hpp"
-#include "query.hpp"
-#include <QNetworkAccessManager>
 
 using namespace Huggle;
 

--- a/huggle/updateform.cpp
+++ b/huggle/updateform.cpp
@@ -9,6 +9,8 @@
 //GNU General Public License for more details.
 
 #include "updateform.hpp"
+#include <QtXml>
+#include <QFile>
 #include <QDesktopServices>
 #if QT_VERSION >= 0x050000
 #include <QTemporaryDir>
@@ -30,8 +32,6 @@
 #include "syslog.hpp"
 #include "ui_updateform.h"
 #include "webserverquery.hpp"
-#include <QtXml>
-#include <QFile>
 
 #define LOG Syslog::HuggleLogs->Log
 


### PR DESCRIPTION
We might need to update the headers here, some macros, like _l are conflicting with standard C/C++ headers in OSX Darwin. Moving the includes before our headers that define these macros, should fix the problem.