### PR TITLE
Make it more convenient to close

### DIFF
--- a/src/huggle_ui/editform.cpp
+++ b/src/huggle_ui/editform.cpp
@@ -115,8 +115,8 @@ void EditForm::DisplayPreview(QString html)
 
 void EditForm::FinishEdit()
 {
-    UiGeneric::pMessageBox(this, "Edited", "Page was successfuly edited, you can close this form now");
-    this->webView->RenderHtml(":)");
+    UiGeneric::pMessageBox(this, "Edited", "Page was successfuly edited");
+    this->hide();
 }
 
 void EditForm::FailEdit(QString reason)


### PR DESCRIPTION
It can close the edit form directly and only leaving the "successful edit" message.