### PR TITLE
Adding the option "Grouping in {{multiple issues}}" in page tagging

### DIFF
--- a/src/huggle_core/projectconfiguration.cpp
+++ b/src/huggle_core/projectconfiguration.cpp
@@ -344,7 +344,7 @@ bool ProjectConfiguration::Parse(QString config, QString *reason, WikiSite *site
         }
         if (this->TagsDesc.contains(info[0]))
         {
-            Syslog::HuggleLogs->DebugLog("Multiple taginfo: " + tag);
+            Syslog::HuggleLogs->DebugLog("Multiple tag info: " + tag);
             continue;
         }
         if (!this->Tags.contains(info[0]))

--- a/src/huggle_core/projectconfiguration.cpp
+++ b/src/huggle_core/projectconfiguration.cpp
@@ -778,6 +778,7 @@ bool ProjectConfiguration::ParseYAML(QString yaml_src, QString *reason, WikiSite
     this->WarningSummaries.insert(2, HuggleParser::YAML2String("warn-summary-2", yaml, "Level 2 re. [[$1]]"));
     this->WarningSummaries.insert(3, HuggleParser::YAML2String("warn-summary-3", yaml, "Level 3 re. [[$1]]"));
     this->WarningSummaries.insert(4, HuggleParser::YAML2String("warn-summary-4", yaml, "Level 4 re. [[$1]]"));
+    this->GroupTag = HuggleParser::YAML2String("group-tag", yaml, this->GroupTag);
 
     // Month headers
     QStringList MonthsHeaders_ = HuggleParser::YAML2QStringList("months", yaml);

--- a/src/huggle_core/projectconfiguration.hpp
+++ b/src/huggle_core/projectconfiguration.hpp
@@ -241,6 +241,7 @@ namespace Huggle
             // Templates
             QString         SharedIPTemplateTags = "";
             QString         SharedIPTemplate = "";
+            QString         GroupTag = "multiple issues";
 
             // Definitions
             QHash<QString, int>     ScoreTags;

--- a/src/huggle_core/scripting/jsmarshallinghelper.cpp
+++ b/src/huggle_core/scripting/jsmarshallinghelper.cpp
@@ -131,7 +131,7 @@ QJSValue JSMarshallingHelper::FromPage(WikiPage *page, QJSEngine *engine)
         return QJSValue(false);
     QJSValue o = engine->newObject();
     o.setProperty("ContentModel", QJSValue(page->ContentModel));
-    o.setProperty("Contents", QJSValue(page->Contents));
+    o.setProperty("Contents", QJSValue(page->GetContent()));
     o.setProperty("EncodedName", QJSValue(page->EncodedName()));
     o.setProperty("FounderKnown", QJSValue(page->FounderKnown()));
     o.setProperty("Founder", QJSValue(page->GetFounder()));

--- a/src/huggle_core/wikiedit.cpp
+++ b/src/huggle_core/wikiedit.cpp
@@ -292,7 +292,7 @@ bool WikiEdit::finalizePostProcessing()
         {
             ApiQueryResultNode *revision = revision_data.at(0);
             if (revision->Value.length() > 0)
-                this->Page->Contents = revision->Value;
+                this->Page->SetContent(revision->Value);
             // check if this revision matches our user
             if (revision->Attributes.contains("user"))
             {
@@ -377,8 +377,8 @@ bool WikiEdit::finalizePostProcessing()
         }
         else
         {
-            this->Page->Contents = result;
-            this->Page->Contents.replace("//", "https://");
+            result.replace("//", "https://");
+            this->Page->SetContent(result);
         }
         this->qText = nullptr;
     }

--- a/src/huggle_core/wikipage.cpp
+++ b/src/huggle_core/wikipage.cpp
@@ -39,6 +39,7 @@ WikiPage::WikiPage(WikiPage *page) : MediaWikiObject(page)
     this->Contents = page->Contents;
     this->founder = page->founder;
     this->founderKnown = page->founderKnown;
+    this->hasContent = page->hasContent;
     this->NS = page->NS;
 }
 
@@ -113,6 +114,22 @@ QString WikiPage::RootName()
 QString WikiPage::EncodedName()
 {
     return QUrl::toPercentEncoding(this->PageName);
+}
+
+QString WikiPage::GetContent()
+{
+    return this->Contents;
+}
+
+void WikiPage::SetContent(QString content)
+{
+    this->hasContent = true;
+    this->Contents = content;
+}
+
+bool WikiPage::HasContent()
+{
+    return this->hasContent;
 }
 
 bool WikiPage::IsTalk()

--- a/src/huggle_core/wikipage.hpp
+++ b/src/huggle_core/wikipage.hpp
@@ -52,15 +52,20 @@ namespace Huggle
             void SetCategories(QStringList value);
             bool IsWatched();
             void SetWatched(bool value);
+            QString GetContent();
+            void SetContent(QString content);
+            //! Whether this instance of WikiPage contains its content, if false, it means that content of this page is unknown
+            bool HasContent();
             QString Contents;
             //! Content model of a page, if known
             QString ContentModel;
             //! Name of page
             QString PageName;
-        private:
+        protected:
             QStringList categories;
             WikiPageNS *NS;
             QString founder;
+            bool hasContent = false;
             bool founderKnown = false;
             bool watched = false;
     };

--- a/src/huggle_l10n/Localization/en.xml
+++ b/src/huggle_l10n/Localization/en.xml
@@ -858,6 +858,7 @@
   <string name="queue-empty-title">It's empty</string>
   <string name="queue-empty-text">There is nothing else in the queue...</string>
   <string name="protip">ProTip</string>
+  <string name="wikipagetagsform-group">Group inside {{$1}}</string>
   <string name="tip1">Huggle supports tabs just like any other web browser! If you are on an edit and you want to keep it for later, you can simply open a new tab and continue checking the queue there. The queue is shared amongst all tabs.</string>
   <string name="tip2">Huggle contains an "edit bar", a little widget that contains both the User and Page history in a neat way. It's not enabled by default though. If you are on a small screen, you can replace user and page history widgets with it!</string>
   <string name="tip3">Most preferences are stored on the wiki in [[Special:MyPage/huggle3.css]]. You can also manually change them there.</string>

--- a/src/huggle_ui/history.cpp
+++ b/src/huggle_ui/history.cpp
@@ -278,7 +278,7 @@ void History::Tick()
             edit->Page = new WikiPage(this->RevertingItem->Target, site);
         }
         edit->User = new WikiUser(Configuration::HuggleConfiguration->SystemConfig_Username, site);
-        edit->Page->Contents = result;
+        edit->Page->SetContent(result);
         edit->RevID = revid;
         if (this->RevertingItem->NewPage && this->RevertingItem->Type == HistoryMessage)
         {

--- a/src/huggle_ui/mainwindow.cpp
+++ b/src/huggle_ui/mainwindow.cpp
@@ -3222,9 +3222,8 @@ void MainWindow::on_actionTag_2_triggered()
 
     if (this->fWikiPageTags)
         delete this->fWikiPageTags;
-    this->fWikiPageTags = new WikiPageTagsForm(this);
+    this->fWikiPageTags = new WikiPageTagsForm(this, this->CurrentEdit->Page);
     this->fWikiPageTags->show();
-    this->fWikiPageTags->ChangePage(this->CurrentEdit->Page);
 }
 
 void MainWindow::on_actionReload_menus_triggered()

--- a/src/huggle_ui/wikipagetagsform.cpp
+++ b/src/huggle_ui/wikipagetagsform.cpp
@@ -200,7 +200,7 @@ void Huggle::WikiPageTagsForm_FinishRead(Query *result)
                     }
                     else
                     {
-                        text = ClearTag(tag, text2);
+                        text = ClearTag(tag, text);
                     }
                     text += "\n" + key;
                 }

--- a/src/huggle_ui/wikipagetagsform.cpp
+++ b/src/huggle_ui/wikipagetagsform.cpp
@@ -163,7 +163,6 @@ void Huggle::WikiPageTagsForm_FinishRead(Query *result)
     // append all tags to top of page or bottom, depending on preference of user, if requested group into one template
     if (form->ui->checkBox_2->isChecked() && !form->ui->checkBox->isChecked() && multiple_tags_selected)
     {
-        // User wants to group all templates into one and don't want to put them to bottom in same time (which is not allowed)
         text = "{{" + retrieve->GetSite()->ProjectConfig->GroupTag + "|";
     }
     else if (form->ui->checkBox_2->isChecked() && form->ui->checkBox->isChecked() && multiple_tags_selected)
@@ -238,6 +237,7 @@ void Huggle::WikiPageTagsForm::on_pushButton_clicked()
     this->ui->pushButton->setEnabled(false);
     this->ui->checkBox->setEnabled(false);
     this->ui->tableWidget->setEnabled(false);
+    this->ui->checkBox_2->setEnabled(false);
     // first get the contents of the page
     ApiQuery *retrieve = WikiUtil::RetrieveWikiPageContents(this->page, false);
     retrieve->FailureCallback = (Callback)Fail;
@@ -245,13 +245,4 @@ void Huggle::WikiPageTagsForm::on_pushButton_clicked()
     retrieve->SuccessCallback = (Callback)Huggle::WikiPageTagsForm_FinishRead;
     QueryPool::HugglePool->AppendQuery(retrieve);
     retrieve->Process();
-}
-
-void Huggle::WikiPageTagsForm::on_checkBox_stateChanged(int arg1)
-{
-    bool checked = arg1 == Qt::Checked;
-    this->ui->checkBox_2->setEnabled(!checked);
-    // Make sure it's not active together
-    if (checked)
-        this->ui->checkBox_2->setChecked(false);
 }

--- a/src/huggle_ui/wikipagetagsform.hpp
+++ b/src/huggle_ui/wikipagetagsform.hpp
@@ -43,8 +43,6 @@ namespace Huggle
             void ChangePage(WikiPage *wikipage);
         private slots:
             void on_pushButton_clicked();
-            void on_checkBox_stateChanged(int arg1);
-
         private:
             friend void Huggle::WikiPageTagsForm_FinishRead(Query *result);
             WikiPage *page = nullptr;

--- a/src/huggle_ui/wikipagetagsform.hpp
+++ b/src/huggle_ui/wikipagetagsform.hpp
@@ -38,13 +38,16 @@ namespace Huggle
     {
             Q_OBJECT
         public:
-            explicit WikiPageTagsForm(QWidget *parent = nullptr);
+            explicit WikiPageTagsForm(QWidget *parent, WikiPage *wikipage);
             ~WikiPageTagsForm();
-            void ChangePage(WikiPage *wikipage);
         private slots:
             void on_pushButton_clicked();
         private:
             friend void Huggle::WikiPageTagsForm_FinishRead(Query *result);
+            void toggleEnable(bool enable);
+            void displayTags();
+            void getPageContents();
+            bool initializing = true;
             WikiPage *page = nullptr;
             QHash<QString,QLineEdit*> Arguments;
             QHash<QString,QCheckBox*> CheckBoxes;

--- a/src/huggle_ui/wikipagetagsform.hpp
+++ b/src/huggle_ui/wikipagetagsform.hpp
@@ -43,6 +43,8 @@ namespace Huggle
             void ChangePage(WikiPage *wikipage);
         private slots:
             void on_pushButton_clicked();
+            void on_checkBox_stateChanged(int arg1);
+
         private:
             friend void Huggle::WikiPageTagsForm_FinishRead(Query *result);
             WikiPage *page = nullptr;

--- a/src/huggle_ui/wikipagetagsform.ui
+++ b/src/huggle_ui/wikipagetagsform.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>519</width>
-    <height>242</height>
+    <width>687</width>
+    <height>377</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
@@ -16,6 +22,9 @@
   <property name="windowIcon">
    <iconset resource="../huggle_res/pictures.qrc">
     <normaloff>:/huggle/pictures/Resources/huggle3_newlogo.ico</normaloff>:/huggle/pictures/Resources/huggle3_newlogo.ico</iconset>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>false</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -27,6 +36,13 @@
    </item>
    <item>
     <widget class="QTableWidget" name="tableWidget"/>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_2">
+     <property name="text">
+      <string>Group inside {{multiple issues}}</string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QCheckBox" name="checkBox">


### PR DESCRIPTION
I also improved the config page -> https://en.wikipedia.org/w/index.php?title=Wikipedia%3AHuggle%2FConfig.yaml&type=revision&diff=855878898&oldid=852506898. However, the descriptions are still not working. 
![screen shot 2018-08-21 at 20 55 26](https://user-images.githubusercontent.com/36526983/44402527-a9edcc00-a584-11e8-8a90-72d3f7de3b4b.png)
