### PR TITLE
snap: Fix FTBFS

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,13 +20,19 @@ apps:
 
 parts:
   application:
-    prepare: ./build/prepare_snap.sh
+    source-type: git
     plugin: cmake
     configflags:
       - -DQT5_BUILD=true
       - -DLINUX_SNAP=true
       - -DHUGGLE_EXT=true
-    source: src/
+    source-subdir: src
+    override-build: |
+      cd ../src/src/huggle_core
+      ./update.sh
+      cp definitions_prod.hpp definitions.hpp
+      snapcraftctl build
+
     stage-packages:
       - libxkbcommon0
       - ttf-ubuntu-font-family

--- a/src/build/prepare_snap.sh
+++ b/src/build/prepare_snap.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-cd ../src || exit 1
-echo "Preparing in `pwd`"
-git submodule init
-git submodule update
-cd huggle_core || exit 1
-sh update.sh
-cp definitions_prod.hpp definitions.hpp || exit 1


### PR DESCRIPTION
Closes #307

Handle path differences that changed in between versions of ``snapcraft``.
Drop explicit submodule handling in favour of ``source-type: git``.