### PR TITLE
Improve default report-auto-summary...

### DIFF
--- a/src/huggle_core/projectconfiguration.cpp
+++ b/src/huggle_core/projectconfiguration.cpp
@@ -678,7 +678,7 @@ bool ProjectConfiguration::ParseYAML(const QString& yaml_src, QString *reason, W
             HUGGLE_WARNING("Uknown report mode, falling back to default");
     }
     this->ReportSummary = HuggleParser::YAML2String("report-summary", yaml);
-    this->ReportAutoSummary = HuggleParser::YAML2String("report-auto-summary", yaml, "This user was automatically reported by Huggle due to reverted vandalism after four warnings, please verify their"\
+    this->ReportAutoSummary = HuggleParser::YAML2String("report-auto-summary", yaml, "This user was automatically reported by Huggle due to reverted vandalism after a final warning. Please verify their"\
                                                                                      " contributions carefully, it may be a false positive");
     this->SpeedyTemplates = Yaml_FetchSpeedyOptions(yaml);
     // Templates


### PR DESCRIPTION
...to match the actual technical meaning that works regardless of how many warning levels a project has, and regardless of how many have actually been given.