### PR TITLE
Properly handle time zones for timestamps from MW.

### DIFF
--- a/src/huggle_core/mediawiki.cpp
+++ b/src/huggle_core/mediawiki.cpp
@@ -14,7 +14,9 @@ using namespace Huggle;
 
 QDateTime MediaWiki::FromMWTimestamp(QString timestamp)
 {
-    return QDateTime::fromString(timestamp, "yyyy-MM-ddThh:mm:ssZ");
+    QDateTime date = QDateTime::fromString(timestamp, "yyyy-MM-ddThh:mm:ssZ");
+    date.setTimeSpec(Qt::UTC);
+    return date;
 }
 
 QString MediaWiki::ToMWTimestamp(QDateTime DateTime_)


### PR DESCRIPTION
This should fix the issue with "talk page edited too recently" for hours after the warning.