### PR TITLE
Fix a missing 'else' keyword in the Core::ExtensionLoad function

### DIFF
--- a/src/huggle_core/core.cpp
+++ b/src/huggle_core/core.cpp
@@ -258,6 +258,7 @@ void Core::ExtensionLoad()
                             Huggle::Syslog::HuggleLogs->WarningLog("Extension " + ename + " was compiled for huggle " + interface->CompiledFor() + " which is not compatible, unloading");
                             delete interface;
                         }
+                        else
                         {
                             interface->huggle__internal_SetPath(ename);
                             if (interface->RequestNetwork())


### PR DESCRIPTION
There is a missing `else` keyword in the `Core::ExtensionLoad` function, which can lead to undefined behavior when using the `interface` variable.