### PR TITLE
Fix silent aiv segfault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ hunker/makefilehunker
 version.txt
 *.autosave
 /huggle.pro.user
+
+/release
+/debug

--- a/src/huggle_ui/reportuser.cpp
+++ b/src/huggle_ui/reportuser.cpp
@@ -311,8 +311,8 @@ void ReportUser::OnReportUserTimer()
                     UiGeneric::pMessageBox(this, "Failure", _l("report-fail", this->qEdit->GetFailureReason()), MessageBoxStyleError);
                     Syslog::HuggleLogs->DebugLog("REPORT: " + this->qEdit->Result->Data);
                     this->kill();
-                    return;
                 }
+                return;
             }
             this->reportedUser->IsReported = true;
             this->ui->pushButton->setText(_l("report-done"));


### PR DESCRIPTION
When automatic reporting a user to AIV fails for whatever reason (e.g. an edit conflict), Huggle crashes with a segmentation fault.
The cause for this is that the ReportUser object is accessed after it has been freed.

### Test Plan
I set up Huggle on my local MediaWiki instance, and protected the AIV page to cause the reporting to fail. After the small patch. Huggle doesn't crash anymore.