### PR TITLE
Use GNUInstallDirs rather than hardcoding paths

### DIFF
--- a/src/huggle/CMakeLists.txt
+++ b/src/huggle/CMakeLists.txt
@@ -6,6 +6,7 @@ if (NOT HUGGLE_CMAKE)
 endif()
 
 project(huggle)
+include(GNUInstallDirs)
 
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Gui REQUIRED)
@@ -41,5 +42,5 @@ target_link_libraries(huggle Qt5::Core Qt5::Gui Qt5::Widgets)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 install(FILES ${CMAKE_SOURCE_DIR}/huggle/man/huggle.1 DESTINATION share/man/man1)
-install(TARGETS huggle DESTINATION bin)
+install(TARGETS huggle DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${CMAKE_SOURCE_DIR}/build/huggle.desktop DESTINATION share/applications)

--- a/src/huggle_core/CMakeLists.txt
+++ b/src/huggle_core/CMakeLists.txt
@@ -8,6 +8,8 @@ endif()
 project(huggle_core)
 execute_process(COMMAND "${CMAKE_SOURCE_DIR}/update.sh" WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+include(GNUInstallDirs)
+
 set(CMAKE_include_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
@@ -51,5 +53,5 @@ endif()
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 IF (NOT WIN32)
-    INSTALL(TARGETS huggle_core LIBRARY DESTINATION lib)
+    INSTALL(TARGETS huggle_core LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 ENDIF()

--- a/src/huggle_l10n/CMakeLists.txt
+++ b/src/huggle_l10n/CMakeLists.txt
@@ -6,6 +6,7 @@ if (NOT HUGGLE_CMAKE)
 endif()
 
 project(huggle_l10n)
+include(GNUInstallDirs)
 
 set(CMAKE_include_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -40,5 +41,5 @@ target_link_libraries(huggle_l10n Qt5::Core Qt5::Xml)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 IF (NOT WIN32)
-    INSTALL(TARGETS huggle_l10n LIBRARY DESTINATION lib)
+    INSTALL(TARGETS huggle_l10n LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 ENDIF()

--- a/src/huggle_res/CMakeLists.txt
+++ b/src/huggle_res/CMakeLists.txt
@@ -6,6 +6,7 @@ if (NOT HUGGLE_CMAKE)
 endif()
 
 project(huggle_res)
+include(GNUInstallDirs)
 
 set(CMAKE_include_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -42,4 +43,4 @@ endif()
 target_link_libraries(huggle_res Qt5::Core Qt5::Xml)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-INSTALL(TARGETS huggle_res DESTINATION lib)
+INSTALL(TARGETS huggle_res DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/huggle_ui/CMakeLists.txt
+++ b/src/huggle_ui/CMakeLists.txt
@@ -6,6 +6,8 @@ if (NOT HUGGLE_CMAKE)
 endif()
 
 project(huggle_ui)
+include(GNUInstallDirs)
+
 set(CMAKE_include_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 find_package(Qt5Core REQUIRED)
@@ -79,4 +81,4 @@ if (AUDIO)
 endif()
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-INSTALL(TARGETS huggle_ui DESTINATION lib)
+INSTALL(TARGETS huggle_ui DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Updated CMakeLists.txt for:

* src/huggle
* src/huggle_core
* src/huggle_l10n
* src/huggle_res
* src/huggle_ui

These are now using variables provided by GNUInstallDirs so that we don't have to hardcode paths anymore. This means that libs built for 64-bit systems go into lib64 instead of lib!

I have not tested that this doesn't break anything on Windows or macOS, only on Fedora 33. I'd recommend running at least one test build on each OS before merging this PR.

Also please note comparable [PR](https://github.com/grumpy-irc/libirc/pull/1) for the upstream [libirc](https://github.com/grumpy-irc/libirc).