### PR TITLE
Minor documentation bugfix

### DIFF
--- a/windows64/veyor.ps1
+++ b/windows64/veyor.ps1
@@ -66,7 +66,7 @@ function PackageTest
     if (!(Test-Path $PackageUrl))
     {
         echo "ERROR"
-        echo "Unable to find $PackageName at $PackageUrl, you can set the alternative path using -$VariableName=path"
+        echo "Unable to find $PackageName at $PackageUrl, you can set the alternative path using -$VariableName path"
         exit 1
     }
     echo ("OK");


### PR DESCRIPTION
In the Appveyor script, there is a minor bug, where the documentation for the proper syntax calls for using an equals sign rather than a space. This PR fixes that.