### PR TITLE
Create a Github Actions workflow for Linux, macOS and Windows

### DIFF
--- a/.github/workflows/huggle.yml
+++ b/.github/workflows/huggle.yml
@@ -1,0 +1,58 @@
+name: huggle
+
+on: push
+
+jobs:
+  build-linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    env:
+      QTTYPE: 5
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt-get update
+      - run: travis/install.sh
+      - run: travis/before_script.sh
+      - run: travis/script.sh
+
+  build-macos:
+    name: macOS
+    runs-on: macos-10.15
+    env:
+      QTTYPE: 5
+    steps:
+      - uses: jurplel/install-qt-action@v2
+        with:
+          modules: 'qtwebengine'
+      - uses: actions/checkout@v2
+      - run: travis/before_install_osx.sh
+      - run: travis/install_osx.sh
+      - run: travis/before_script_osx.sh
+      - run: travis/script_osx.sh
+
+  build-windows:
+    name: Windows
+    runs-on: windows-latest
+    env:
+      QTTYPE: 5
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: jurplel/install-qt-action@v2
+        with:
+          modules: 'qtwebengine'
+      - uses: microsoft/setup-msbuild@v1.0.2
+      - run: $env:RUNNER_WORKSPACE
+      - run: $env:Qt5_Dir
+      - name: run appveyor script
+        shell: pwsh
+        working-directory: ./windows64
+        run: |
+          $msbuildpath = vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | select-object -first 1
+          if ($path) {
+          & $path $args
+          }
+          $env:Qt5_Dir
+          ./veyor.ps1 -msbuild_path $msbuildpath -qt5_path $env:Qt5_Dir

--- a/.github/workflows/huggle.yml
+++ b/.github/workflows/huggle.yml
@@ -44,8 +44,6 @@ jobs:
         with:
           modules: 'qtwebengine'
       - uses: microsoft/setup-msbuild@v1.0.2
-      - run: $env:RUNNER_WORKSPACE
-      - run: $env:Qt5_Dir
       - name: run appveyor script
         shell: pwsh
         working-directory: ./windows64


### PR DESCRIPTION
This PR adds a GitHub Actions workflow, written based on the existing Travis-CI and AppVeyor build pipelines.

At this time, no changes have been made to the actual scripts used in the build process, so AppVeyor and Travis-CI will continue to work as they have for the time being.

As currently configured, CI is only run when commits are made to the repository. However, it is a simple process to include PRs, which may be something we want.

I've prepared a simple table showing the differences between the build environments for each operating system.

| Build System | Operating System | Specs |
| ------------- | ------------------ | ------ |
| AppVeyor (Windows) | Windows Server 2012 R2 | [2-core, 6GB RAM](https://www.appveyor.com/docs/build-environment/#build-vm-configurations) |
| Travis-CI (Linux) | Ubuntu 16.04 | [2-core, 7.5GB RAM](https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system) |
| Travis-CI (Mac) | macOS 10.13 (High Sierra) | [2-core, 4GB RAM](https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system)| 
| GitHub Actions (Windows) | Windows Server 2019 | [2-core, 7GB RAM](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)
| GitHub Actions (Linux) | Ubuntu 18.04 | [2-core, 7GB RAM](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)
| GitHub Actions (macOS) | macOS 10.15 (Catalina) | [3-core, 14GB RAM](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) | 

As you can see, the operating systems are more modern, and the hardware specs are generally better.

Of note, macOS builds are running on a more modern OS, have an additional CPU core, and more than triple the RAM as compared to the Travis-CI infrastructure. Linux builds have slightly less ram than on Travis-CI, but complete in a comparable timeframe. [Linux builds will soon be automatically migrated to Ubuntu 20.04](https://github.com/actions/virtual-environments/issues/1816), with no action needed, as the ubuntu-latest tag will be redirected to 20.04.

Additionally, when macOS 11 (Big Sur) becomes available for everyone to use in GitHub Actions, there is a simple process to add that, which I will be happy to do. Currently, [GitHub Actions is not allowing new organizations to begin using the macOS 11 build environments yet](https://github.com/actions/virtual-environments/issues/2486), as they are seeing more demand for that buildsystem than they are ready for at the moment.

If there are any questions about this workflow, I am happy to answer here, or on IRC in #huggle on Freenode.