### PR TITLE
[GitHub Actions] Support Multiple OSes and Qt Versions

### DIFF
--- a/.github/workflows/huggle.yml
+++ b/.github/workflows/huggle.yml
@@ -5,36 +5,52 @@ on: push
 jobs:
   build-linux:
     name: Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-${{ matrix.ubuntu-version }}
     env:
       QTTYPE: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu-version: [16.04, 18.04, 20.04]
+        qt-version: [5.12.10, 5.15.2]
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get update
-      - run: travis/install.sh
+      - uses: jurplel/install-qt-action@v2
+        with:
+          version: ${{ matrix.qt-version }}
+          modules: 'qtwebengine'
       - run: travis/before_script.sh
       - run: travis/script.sh
 
   build-macos:
     name: macOS
-    runs-on: macos-10.15
+    runs-on: macos-latest
     env:
       QTTYPE: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        qt-version: [5.12.10, 5.15.2]
     steps:
       - uses: jurplel/install-qt-action@v2
         with:
+          version: ${{ matrix.qt-version }}
           modules: 'qtwebengine'
       - uses: actions/checkout@v2
       - run: travis/before_install_osx.sh
-      - run: travis/install_osx.sh
       - run: travis/before_script_osx.sh
       - run: travis/script_osx.sh
 
   build-windows:
     name: Windows
-    runs-on: windows-latest
+    runs-on: windows-${{ matrix.windows-version }}
     env:
       QTTYPE: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        windows-version: [2016, 2019]
+        qt-version: [5.12.10, 5.15.2]
     steps:
       - name: checkout code
         uses: actions/checkout@v2
@@ -42,6 +58,7 @@ jobs:
           submodules: recursive
       - uses: jurplel/install-qt-action@v2
         with:
+          version: ${{ matrix.qt-version }}
           modules: 'qtwebengine'
       - uses: microsoft/setup-msbuild@v1.0.2
       - name: run appveyor script
@@ -52,5 +69,4 @@ jobs:
           if ($path) {
           & $path $args
           }
-          $env:Qt5_Dir
           ./veyor.ps1 -msbuild_path $msbuildpath -qt5_path $env:Qt5_Dir

--- a/travis/before_script.sh
+++ b/travis/before_script.sh
@@ -4,7 +4,7 @@ g++ --version
 cmake --version
 
 if [ "$QTTYPE" = "5" ]; then
-    ./configure --tests --extension
+    ./configure --tests --extension --web-engine
     cd release
     make || exit 1
 fi


### PR DESCRIPTION
This PR implements a matrix of various OSes and Qt versions for the workflow. Each commit will run every permutation of Qt version and OS version. To see this matrix, you can check [this commit on my fork](https://github.com/phuzion/huggle3-qt-lx/actions/runs/658154510). Adding new Qt versions (for example, if we wanted to add Qt6) is as simple as adding the versions to the `qt-version:` variable.

The Qt versions included are 5.12.10 and 5.15.2.

Windows includes Server 2016 and 2019.

Ubuntu includes 16.04, 18.04 and 20.04.

macOS only includes 10.15 at this time.

Ubuntu and Mac builds now use [jurplel/install-qt-action](https://github.com/jurplel/install-qt-action) to install Qt, which allows us to specify Qt versions without needing to use third-party repos.