### PR TITLE
T218740 close report and block forms after completion

### DIFF
--- a/src/huggle_ui/blockuserform.cpp
+++ b/src/huggle_ui/blockuserform.cpp
@@ -133,6 +133,7 @@ void BlockUserForm::Block()
     this->timer->stop();
     if (this->ui->cbMessageTarget->isChecked())
         this->sendBlockNotice(nullptr);
+    this->close;
 }
 
 void BlockUserForm::Failed(QString reason)

--- a/src/huggle_ui/blockuserform.cpp
+++ b/src/huggle_ui/blockuserform.cpp
@@ -133,7 +133,7 @@ void BlockUserForm::Block()
     this->timer->stop();
     if (this->ui->cbMessageTarget->isChecked())
         this->sendBlockNotice(nullptr);
-    this->close;
+    this->close();
 }
 
 void BlockUserForm::Failed(QString reason)

--- a/src/huggle_ui/blockuserform.cpp
+++ b/src/huggle_ui/blockuserform.cpp
@@ -133,7 +133,10 @@ void BlockUserForm::Block()
     this->timer->stop();
     if (this->ui->cbMessageTarget->isChecked())
         this->sendBlockNotice(nullptr);
-    this->close();
+    // Close window after 2 seconds
+    QTimer::singleShot(2000, [this]()->void{
+        this->close();
+    });
 }
 
 void BlockUserForm::Failed(QString reason)

--- a/src/huggle_ui/reportuser.cpp
+++ b/src/huggle_ui/reportuser.cpp
@@ -324,6 +324,7 @@ void ReportUser::OnReportUserTimer()
                 //this->close();
                 delete this;
             }
+            this->close;
         }
         return;
     }

--- a/src/huggle_ui/reportuser.cpp
+++ b/src/huggle_ui/reportuser.cpp
@@ -324,7 +324,10 @@ void ReportUser::OnReportUserTimer()
                 //this->close();
                 delete this;
             }
-            this->close();
+            // Close window after 2 seconds
+            QTimer::singleShot(2000, [this]()->void{
+                this->close();
+            });
         }
         return;
     }

--- a/src/huggle_ui/reportuser.cpp
+++ b/src/huggle_ui/reportuser.cpp
@@ -324,7 +324,7 @@ void ReportUser::OnReportUserTimer()
                 //this->close();
                 delete this;
             }
-            this->close;
+            this->close();
         }
         return;
     }


### PR DESCRIPTION
close() is called on qwidget after completion of task. Could also add a generic message window with "user blocked" or "reported" at the end.