### PR TITLE
Switch official IRC network to Libera Chat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,6 @@ script:
 notifications: 
   irc: 
     channels: 
-      - "chat.freenode.net#huggle"
+      - "irc.libera.chat#huggle"
     on_failure: always
     on_success: change

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at huggle@lists.wikimedia.org (public mailing list), IRC channel #huggle at freenode or by directly contacting the project maintainers, see https://meta.wikimedia.org/wiki/Huggle/Members for list of admins. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at huggle@lists.wikimedia.org (public mailing list), IRC channel #huggle at Libera Chat or by directly contacting the project maintainers, see https://meta.wikimedia.org/wiki/Huggle/Members for list of admins. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For users: [on metawiki](https://meta.wikimedia.org/wiki/Huggle) and [mediawiki]
 Getting help
 =========
 
-We have an IRC-channel irc://chat.freenode.org/#huggle so if you need any kind of help please go there.
+We have an IRC-channel irc://irc.libera.chat/#huggle so if you need any kind of help please go there.
 
 Contributing
 =========

--- a/src/huggle_core/generic.cpp
+++ b/src/huggle_core/generic.cpp
@@ -171,7 +171,7 @@ QString Generic::ShrinkText(const QString &text, int size, bool html, int minimu
 
 QString Generic::IRCQuitDefaultMessage()
 {
-    return "Huggle (" + hcfg->HuggleVersion + "), the anti vandalism software. See #huggle on irc://chat.freenode.net";
+    return "Huggle (" + hcfg->HuggleVersion + "), the anti vandalism software. See #huggle on irc://irc.libera.chat";
 }
 
 QString Generic::HtmlEncode(const QString& text)


### PR DESCRIPTION
As some folks may be aware, there have been some recent issues that have come to light regarding the ownership and management of Freenode. As a result of this, the entire volunteer staff of Freenode has resigned.

Many projects are packing up and moving to Libera, which is a new IRC network founded by the previous staff of Freenode.

For more information about this situation, please read this: https://gist.github.com/joepie91/df80d8d36cd9d1bde46ba018af497409

This PR points to the new Libera Chat network in a handful of places:

* Documentation such as `CODE_OF_CONDUCT.MD` and `README.md`
* Travis-CI configuration
* The default IRC quit message

I simply performed a `grep -ir freenode .` in the root directory, so if there are any other references to Freenode that I missed, please suggest them and I will add them.

If the community decides that switching to Libera is a good move, merging this PR should handle all of the "code" changes that are necessary to point future releases to the new network.

Note: This PR does nothing with regard to the Huggle Antivandalism Network (HAN). That is still hosted at `irc.tm-irc.org` and there are no plans to change that at this time.