### PR TITLE
Enabling GHA on Pull Requests

### DIFF
--- a/.github/workflows/huggle.yml
+++ b/.github/workflows/huggle.yml
@@ -1,6 +1,8 @@
 name: huggle
 
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   build-linux:


### PR DESCRIPTION
This PR enables GitHub Actions on Pull Requests, in addition to on commits.