### PR TITLE
Removing Ubuntu 16.04 LTS

### DIFF
--- a/.github/workflows/huggle.yml
+++ b/.github/workflows/huggle.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu-version: [16.04, 18.04, 20.04]
+        ubuntu-version: [18.04, 20.04]
         qt-version: [5.12.10, 5.15.2]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
As mentioned in #347, GitHub Actions is removing Ubuntu 16.04 LTS on September 20, 2021. This PR closes #347 by removing 16.04 from the matrix of Ubuntu versions we build against.