### PR TITLE
Added automatic upload of nightly build to server stored in repo secrets

### DIFF
--- a/.github/workflows/huggle.yml
+++ b/.github/workflows/huggle.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        windows-version: [2016, 2019]
+        windows-version: [2016, latest]
         qt-version: [5.12.10, 5.15.2]
     steps:
       - name: checkout code
@@ -72,3 +72,15 @@ jobs:
           & $path $args
           }
           ./veyor.ps1 -msbuild_path $msbuildpath -qt5_path $env:Qt5_Dir
+      - name: build huggle3.zip
+        if: ( runner.os == 'Windows' ) && ( matrix.windows-version == 'latest' ) && ( matrix.qt-version == '5.15.2' )
+        run: 7z a huggle3.zip windows64\release
+      - name: install ssh key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.KEY }}
+          name: id_ed25519
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+      - name: upload nightlies
+        if: ( runner.os == 'Windows' ) && ( matrix.windows-version == 'latest' ) && ( matrix.qt-version == '5.15.2' )
+        run: echo "put huggle3.zip" | sftp -4 ${{ secrets.USERNAME }}@${{ secrets.HOST }}:${{ secrets.UPLOADPATH }}


### PR DESCRIPTION
This PR adds the automatic upload of nightly builds to an off-site server via SFTP using a predefined SSH key stored in GitHub Secrets.

As proof that this works, I submit [my most recent commit to this branch](https://github.com/phuzion/huggle3-qt-lx/commit/87e6f9c6f936e3a4d3bdc4122517844086e83c00) and the [associated GitHub Actions workflow run](https://github.com/phuzion/huggle3-qt-lx/actions/runs/1144970246) to go along with it.

As a note, the SFTP command is currently forced to use IPv4. This can be changed by removing `-4` from the `run:` command.

Prior to merging this PR, the following must be added as Repository Secrets in settings:

- `HOST` - The FQDN of the server to which nightlies will be uploaded
- `USERNAME` - The username of an account authorized to connect and upload to the server
- `KEY` - The full text of a passwordless private key authorized to connect to and upload to the server
- `KNOWN_HOSTS` - A `known_hosts` file, containing the server-key of the server
- `UPLOADPATH` - The absolute path of the directory where the files will be uploaded, with a trailing slash. Example: `/srv/www/` or `/home/user/directory/`

`KNOWN_HOSTS` can be easily generated by moving your local `~/.ssh/known_hosts` to a temporary location, and SSHing to the server. Copy the contents of the new `~/.ssh/known_hosts` file into the `KNOWN_HOSTS` secret, and you should be good to go.

If there are any questions about this PR, I'm happy to answer here or on IRC.