### PR TITLE
switch updater url to https and new location

### DIFF
--- a/src/huggle_ui/updateform.cpp
+++ b/src/huggle_ui/updateform.cpp
@@ -83,7 +83,7 @@ void UpdateForm::Check()
 {
 #ifndef HUGGLE_NOUPDATER
     this->qData = new WebserverQuery();
-    this->qData->URL = "http://tools.wmflabs.org/huggle/updater/?version=" + QUrl::toPercentEncoding(HUGGLE_VERSION)
+    this->qData->URL = "https://huggle.toolforge.org/updater/?version=" + QUrl::toPercentEncoding(HUGGLE_VERSION)
             + "&os=" + QUrl::toPercentEncoding(Configuration::HuggleConfiguration->Platform)
             + "&language=" + Localizations::HuggleLocalizations->PreferredLanguage;
 


### PR DESCRIPTION
btw: https://huggle.toolforge.org/updater/?version=1&os=example&language=en still returns 3.4.6 as newest version, but 3.4.10 is latest