### PR TITLE
Remove deprecated Windows Server 2016

### DIFF
--- a/.github/workflows/huggle.yml
+++ b/.github/workflows/huggle.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        windows-version: [2016, 2019]
+        windows-version: [2019]
         qt-version: [5.12.10, 5.15.2]
     steps:
       - name: checkout code


### PR DESCRIPTION
This PR removes the now deprecated Windows Server 2016 Github Actions runner image, and should fix the currently failing CI. This is a bit of a band-aid fix, as the correct solution is to ensure that Huggle builds on Server 2022 and the latest Visual Studio, which I have tested and does not currently work. This will fix #355.