### PR TITLE
Add $page var in welcomeCurrentUser templating

### DIFF
--- a/src/huggle_ui/mainwindow.cpp
+++ b/src/huggle_ui/mainwindow.cpp
@@ -2459,6 +2459,7 @@ void MainWindow::welcomeCurrentUser(QString message)
         return;
     }
     message.replace("$1", this->CurrentEdit->User->Username);
+    message.replace("$page", this->CurrentEdit->Page->PageName);
     WikiUtil::MessageUser(this->CurrentEdit->User, message, conf->WelcomeTitle, conf->WelcomeSummary, false, nullptr,
                           false, false, true, this->CurrentEdit->TPRevBaseTime, create_only);
 }


### PR DESCRIPTION
Used to fill welcome templates with page title.
Working well on frwiki.
https://fr.wikipedia.org/w/index.php?title=Discussion_utilisateur:La_Casa_Musicale&diff=prev&oldid=210256980 https://fr.wikipedia.org/w/index.php?title=Wikip%C3%A9dia:Huggle/Config.yaml&diff=prev&oldid=210120799