### PR TITLE
Fix IRC RC feed

### DIFF
--- a/src/huggle_core/hugglefeedproviderirc.hpp
+++ b/src/huggle_core/hugglefeedproviderirc.hpp
@@ -65,6 +65,7 @@ namespace Huggle
         private slots:
             void OnIRCChannelMessage(libircclient::Parser *px);
             void OnConnected();
+            void OnParse(libircclient::Parser *px);
             void OnFailure(QString reason, int code);
             void OnDisconnected();
         protected:


### PR DESCRIPTION
This works around an incompatibility between libirc and the new IRC RC server implementation. The new RC server only sends one parameter with the MYINFO command; libirc expects 4, or it won't autojoin. This patch has Huggle take care of sending the join after seeing MYINFO, regardless of the number of arguments.