### PR TITLE
fix(ReportUser::checkUserIsReported): Always failed with Qt6

### DIFF
--- a/src/huggle_ui/reportuser.cpp
+++ b/src/huggle_ui/reportuser.cpp
@@ -599,11 +599,12 @@ bool ReportUser::checkUserIsReported()
 {
     QString regex = this->reportedUser->GetSite()->GetProjectConfig()->ReportUserCheckPattern;
     regex.replace("$username", HREGEX_TYPE::escape(this->reportedUser->Username));
-    HREGEX_TYPE pattern(regex);
 #ifdef QT6_BUILD
+    HREGEX_TYPE pattern(regex, QRegularExpression::DotMatchesEverythingOption);
     QRegularExpressionMatch match = pattern.match(this->reportContent);
     return match.hasMatch() && (match.captured(0) == this->reportContent);
 #else
+    HREGEX_TYPE pattern(regex);
     return pattern.exactMatch(this->reportContent);
 #endif
 }


### PR DESCRIPTION
Another small bug where Huggle would always say a user was not reported at AIV.

The cause is also that QRegularExpression has a different behavior. Here it would only match the single line where the user was reported when the pattern is `.*$username.*`, while QRegExp matched the whole page.

We add the option for DotMatchesEverything, which will match all lines (as before)