### PR TITLE
Fix: CMake 4.0 compatibility issue (T391309)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is a build file for Huggle (used with cmake)
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required (VERSION 2.8.7...4.0.0)
 
 # So that MacOS builds are working on older versions as well
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is a build file for Huggle (used with cmake)
-cmake_minimum_required (VERSION 2.8.7...4.0.0)
+cmake_minimum_required (VERSION 3.5)
 
 # So that MacOS builds are working on older versions as well
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")

--- a/src/huggle/CMakeLists.txt
+++ b/src/huggle/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is a build file for Huggle (used with cmake)
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required (VERSION 2.8.7...4.0.0)
 
 if (NOT HUGGLE_CMAKE)
     message(FATAL_ERROR "This cmake file can't be used on its own, it must be included from parent folder")

--- a/src/huggle/CMakeLists.txt
+++ b/src/huggle/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is a build file for Huggle (used with cmake)
-cmake_minimum_required (VERSION 2.8.7...4.0.0)
+cmake_minimum_required (VERSION 3.5)
 
 if (NOT HUGGLE_CMAKE)
     message(FATAL_ERROR "This cmake file can't be used on its own, it must be included from parent folder")

--- a/src/huggle_core/CMakeLists.txt
+++ b/src/huggle_core/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is a build file for Huggle (used with cmake)
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required (VERSION 2.8.7...4.0.0)
 
 if (NOT HUGGLE_CMAKE)
     message(FATAL_ERROR "This cmake file can't be used on its own, it must be included from parent folder")

--- a/src/huggle_core/CMakeLists.txt
+++ b/src/huggle_core/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is a build file for Huggle (used with cmake)
-cmake_minimum_required (VERSION 2.8.7...4.0.0)
+cmake_minimum_required (VERSION 3.5)
 
 if (NOT HUGGLE_CMAKE)
     message(FATAL_ERROR "This cmake file can't be used on its own, it must be included from parent folder")

--- a/src/huggle_l10n/CMakeLists.txt
+++ b/src/huggle_l10n/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is a build file for Huggle (used with cmake)
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required (VERSION 2.8.7...4.0.0)
 
 if (NOT HUGGLE_CMAKE)
     message(FATAL_ERROR "This cmake file can't be used on its own, it must be included from parent folder")

--- a/src/huggle_l10n/CMakeLists.txt
+++ b/src/huggle_l10n/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is a build file for Huggle (used with cmake)
-cmake_minimum_required (VERSION 2.8.7...4.0.0)
+cmake_minimum_required (VERSION 3.5)
 
 if (NOT HUGGLE_CMAKE)
     message(FATAL_ERROR "This cmake file can't be used on its own, it must be included from parent folder")

--- a/src/huggle_res/CMakeLists.txt
+++ b/src/huggle_res/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is a build file for Huggle (used with cmake)
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required (VERSION 2.8.7...4.0.0)
 
 if (NOT HUGGLE_CMAKE)
     message(FATAL_ERROR "This cmake file can't be used on its own, it must be included from parent folder")

--- a/src/huggle_res/CMakeLists.txt
+++ b/src/huggle_res/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is a build file for Huggle (used with cmake)
-cmake_minimum_required (VERSION 2.8.7...4.0.0)
+cmake_minimum_required (VERSION 3.5)
 
 if (NOT HUGGLE_CMAKE)
     message(FATAL_ERROR "This cmake file can't be used on its own, it must be included from parent folder")

--- a/src/huggle_ui/CMakeLists.txt
+++ b/src/huggle_ui/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is a build file for Huggle (used with cmake)
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required (VERSION 2.8.7...4.0.0)
 
 if (NOT HUGGLE_CMAKE)
     message(FATAL_ERROR "This cmake file can't be used on its own, it must be included from parent folder")

--- a/src/huggle_ui/CMakeLists.txt
+++ b/src/huggle_ui/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is a build file for Huggle (used with cmake)
-cmake_minimum_required (VERSION 2.8.7...4.0.0)
+cmake_minimum_required (VERSION 3.5)
 
 if (NOT HUGGLE_CMAKE)
     message(FATAL_ERROR "This cmake file can't be used on its own, it must be included from parent folder")


### PR DESCRIPTION
<img width="1631" height="474" alt="Screenshot 2025-07-25 114454" src="https://github.com/user-attachments/assets/7952940c-9706-4162-a865-e226e5af186a" />

Fixes T391309
Updated 'cmake_minimum_required()' in
 all relevant 'CMakeLists.txt' files.
After testing,
I updated all CMakeLists.txt files to use cmake_minimum_required(VERSION 3.5) for clean compatibility with CMake 4.0.0. 

Huggle builds and runs correctly on Linux.

This resolves the compatibility error with CMake 4.0.0:
> Compatibility with CMake < 3.5 has been removed...

Tested and verified that Huggle builds and runs correctly with CMake 4.0.0 on Linux.
