### PR TITLE
Fixes T300885

### DIFF
--- a/src/huggle_ui/historyform.cpp
+++ b/src/huggle_ui/historyform.cpp
@@ -277,11 +277,13 @@ void HistoryForm::onTick01()
         }
         else
         {
-            QPoint pntr(0, this->pos().y());
-            if (this->pos().x() > 400)
-                pntr.setX(this->pos().x() - 200);
+            // Calculate tooltip position relative to the screen where the app is located
+            QPoint globalPos = this->mapToGlobal(QPoint(0, 0));
+            QPoint pntr(0, globalPos.y());
+            if (globalPos.x() > 400)
+                pntr.setX(globalPos.x() - 200);
             else
-                pntr.setX(this->pos().x() + 100);
+                pntr.setX(globalPos.x() + 100);
 
             if (hcfg->UserConfig->ShowWarningIfNotOnLastRevision)
             {


### PR DESCRIPTION
replaced this->pos() with this->mapToGlobal(QPoint(0, 0)), which:

- Converts the widget's local coordinates (0,0) to global screen coordinates
- Takes into account which screen the widget is currently on
- Ensures the tooltip appears on the same screen as the application window
- The method mapToGlobal() is a Qt function that transforms a widget's local coordinates to global screen coordinates. By using this instead of pos(), we're properly accounting for the widget's actual position on the screen where it's displayed.

I created this fix on my laptop only with 1 screen so I couldn't check if it really fixes the issue, it needs to be verified on multi-screen system first before merging