### PR TITLE
Fix open in browser shortcut using wrong action name

### DIFF
--- a/src/huggle_ui/mainwindow.cpp
+++ b/src/huggle_ui/mainwindow.cpp
@@ -1077,7 +1077,7 @@ void MainWindow::ReloadShort(const QString& id)
             q = this->ui->actionFlag_as_a_good_edit;
             break;
         case HUGGLE_ACCEL_MAIN_OPEN_IN_BROWSER:
-            q = this->ui->actionOpen_page_in_browser;
+            q = this->ui->actionOpen_in_a_browser;
             break;
         case HUGGLE_ACCEL_MAIN_TALK:
             q = this->ui->actionTalk_page;
@@ -1764,7 +1764,7 @@ void MainWindow::OnTimerTick0()
                 if (*site->UserConfig->Previous_Version > huggle_version)
                 {
                     if (UiGeneric::pMessageBox(this, _l("main-config-version-mismatch-title"),
-                                               _l("main-config-version-mismatch-text", QString(HUGGLE_VERSION), 
+                                               _l("main-config-version-mismatch-text", QString(HUGGLE_VERSION),
                                                   site->UserConfig->Previous_Version->ToString()),
                                                MessageBoxStyleQuestion, true) == QMessageBox::No)
                         continue;
@@ -2567,7 +2567,7 @@ void MainWindow::ChangeProvider(WikiSite *site, int id)
         {
             case HUGGLE_FEED_PROVIDER_IRC:
                 if (!site->GetProjectConfig()->UseIrc)
-                {   
+                {
                     Syslog::HuggleLogs->Log(_l("irc-not"));
                     this->lIRC[site]->setEnabled(false);
                     this->SwitchAlternativeFeedProvider(site);


### PR DESCRIPTION
I noticed that the open page in browser shortcut had not worked for me in a long time. I compared to the code for open history in browser (which does work), and found that the `actionOpen_page_in_browser` was not connected to anything.

The right handler seems to be `on_actionOpen_in_a_browser_triggered`, which is a slightly different name for the same action.

There is also `on_actionDisplay_this_page_in_browser_triggered`, which is yet another one. I'm not sure I know what the difference is between these two, but this patch is enough to fix the disconnected "O" shortcut.


(The IDE also wanted to strip a couple trailing spaces while saving the file)