### PR TITLE
Fix User-Agent logic in WebserverQuery

### DIFF
--- a/src/huggle_core/webserverquery.cpp
+++ b/src/huggle_core/webserverquery.cpp
@@ -58,6 +58,7 @@ void WebserverQuery::Process()
 
     QUrl url = QUrl::fromEncoded(this->URL.toUtf8());
     QNetworkRequest request(url);
+    request.setRawHeader("User-Agent", Configuration::HuggleConfiguration->WebRequest_UserAgent);
     if (this->UsingPOST)
     {
         request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
@@ -66,7 +67,6 @@ void WebserverQuery::Process()
     {
         this->reply = Query::NetworkManager->get(request);
     }
-    request.setRawHeader("User-Agent", Configuration::HuggleConfiguration->WebRequest_UserAgent);
     QObject::connect(this->reply, &QNetworkReply::finished, this, &WebserverQuery::Finished);
     QObject::connect(this->reply, &QIODevice::readyRead, this, &WebserverQuery::ReadData);
     Huggle::Syslog::HuggleLogs->DebugLog("Processing webserver request " + this->URL, 2);


### PR DESCRIPTION
I guess setting the header should be set before sending the request, not after the request was already submitted.

However it will probably not fix https://phabricator.wikimedia.org/T415141 as WebserverQuery appears to only be used in update mechanism and in extensions (like ORES), not in core api calls.