### PR TITLE
Fix deprecation in profiler

### DIFF
--- a/src/huggle_core/huggleprofiler.cpp
+++ b/src/huggle_core/huggleprofiler.cpp
@@ -45,7 +45,7 @@ QList<QString> Profiler::GetRegisteredCounterFunctions()
     // sort the list by number of calls
     QHash<QString, unsigned long long> temp = callCounter;
     QList<unsigned long long> Numbers = temp.values();
-    qSort(Numbers);
+    std::sort(Numbers.begin(), Numbers.end());
     QList<QString> Functions;
     foreach(unsigned long long n, Numbers)
     {


### PR DESCRIPTION
The `qSort` function was deprecated in Qt 5.2 and removed in Qt 6. Upsteam reccomends using `std::sort` instead.