### PR TITLE
Fix asynchronous speedy deletion workflow

### DIFF
--- a/src/huggle_core/collectable_smartptr.cpp
+++ b/src/huggle_core/collectable_smartptr.cpp
@@ -18,6 +18,7 @@
 #include "editquery.hpp"
 #include "exception.hpp"
 #include "gc.hpp"
+#include "message.hpp"
 #include "revertquery.hpp"
 #include "webserverquery.hpp"
 #include "wlquery.hpp"
@@ -34,5 +35,6 @@ namespace Huggle
     template class Collectable_SmartPtr<HistoryItem>;
     template class Collectable_SmartPtr<WLQuery>;
     template class Collectable_SmartPtr<ApiQuery>;
+    template class Collectable_SmartPtr<Message>;
 }
 #endif

--- a/src/huggle_core/wikiedit.cpp
+++ b/src/huggle_core/wikiedit.cpp
@@ -136,23 +136,16 @@ bool WikiEdit::finalizePostProcessing()
             Syslog::HuggleLogs->ErrorLog("Failed to retrieve founder for page " + this->Page->PageName + ": " + this->qFounder->GetFailureReason());
         } else
         {
-            QList<ApiQueryResultNode*> revisions = this->qFounder->GetApiQueryResult()->GetNodes("rev");
-            if (revisions.count() == 0)
+            bool failed;
+            QString error;
+            QString founder = WikiUtil::EvaluatePageFounder(this->qFounder->GetApiQueryResult(), &failed, &error);
+            if (failed)
             {
-                Syslog::HuggleLogs->ErrorLog("Failed to retrieve founder for page " + this->Page->PageName + ": " + this->qFounder->GetFailureReason());
+                Syslog::HuggleLogs->ErrorLog("Failed to retrieve founder for page " + this->Page->PageName + ": " + error);
                 HUGGLE_DEBUG(this->qFounder->Result->Data, 1);
-            }
-            else if (revisions.count() == 1)
+            } else
             {
-                ApiQueryResultNode *node = revisions.at(0);
-                if (!node->Attributes.contains("timestamp") || !node->Attributes.contains("user"))
-                {
-                    HUGGLE_DEBUG1("Invalid revision info while fetching info for page");
-                }
-                else
-                {
-                    this->Page->SetFounder(node->GetAttribute("user"));
-                }
+                this->Page->SetFounder(founder);
             }
         }
         this->qFounder = nullptr;

--- a/src/huggle_core/wikiutil.cpp
+++ b/src/huggle_core/wikiutil.cpp
@@ -513,6 +513,48 @@ WikiSite *WikiUtil::GetSiteByName(QString name)
     return nullptr;
 }
 
+QString WikiUtil::EvaluatePageFounder(ApiQueryResult *result, bool *failed, QString *error)
+{
+    if (!failed)
+        throw new Huggle::NullPointerException("bool *failed", BOOST_CURRENT_FUNCTION);
+
+    *failed = true;
+    if (error)
+        error->clear();
+    if (!result)
+    {
+        if (error)
+            *error = "Query result was NULL";
+        return "";
+    }
+    if (result->IsFailed())
+    {
+        if (error)
+            *error = result->ErrorMessage;
+        return "";
+    }
+
+    QList<ApiQueryResultNode*> revisions = result->GetNodes("rev");
+    if (revisions.count() != 1)
+    {
+        if (error)
+            *error = "The founder query did not return exactly one revision";
+        return "";
+    }
+
+    ApiQueryResultNode *revision = revisions.at(0);
+    QString founder = revision->GetAttribute("user");
+    if (founder.isEmpty())
+    {
+        if (error)
+            *error = "The first revision did not include its author";
+        return "";
+    }
+
+    *failed = false;
+    return founder;
+}
+
 void WikiUtil::PatrolEdit(WikiEdit *edit)
 {
     if (edit == nullptr)

--- a/src/huggle_core/wikiutil.hpp
+++ b/src/huggle_core/wikiutil.hpp
@@ -31,6 +31,7 @@ namespace Huggle
     class EditQuery;
     class RevertQuery;
     class Message;
+    class ApiQueryResult;
     class WikiPage;
     class WikiEdit;
     class WikiSite;
@@ -135,6 +136,7 @@ namespace Huggle
         HUGGLE_EX_CORE QString EvaluateWikiPageContents(ApiQuery *query, bool *failed, QString *ts = nullptr, QString *comment = nullptr,
                                                         QString *user = nullptr, long *revid = nullptr, int *reason = nullptr,
                                                         QString *title = nullptr);
+        HUGGLE_EX_CORE QString EvaluatePageFounder(ApiQueryResult *result, bool *failed, QString *error = nullptr);
         HUGGLE_EX_CORE void PatrolEdit(WikiEdit *edit);
         //! \obsolete RetrieveWikiPageContents(WikiPage *page, bool parse = false);
         HUGGLE_EX_CORE ApiQuery *RetrieveWikiPageContents(const QString &page, WikiSite *site);

--- a/src/huggle_l10n/Localization/en.xml
+++ b/src/huggle_l10n/Localization/en.xml
@@ -766,6 +766,9 @@
   <string name="reqprotection-progress">Requesting protection of &apos;$1&apos;...</string>
   <string name="speedy-fail">Unable to tag page for speedy deletion: $1</string>
   <string name="speedy-progress">Tagging &apos;$1&apos; for speedy deletion...</string>
+  <string name="speedy-notify-progress">Notifying the page creator...</string>
+  <string name="speedy-creator-fail">Unable to determine the page creator: $1</string>
+  <string name="speedy-notification-fail">The page was tagged for speedy deletion, but the creator could not be notified: $1</string>
   <string name="speedy-wrong">The requested tag is not valid. Please choose a different deletion reason</string>
   <string name="speedy-finished">Finished</string>
   <string name="warn-alreadyblocked">The user has already been blocked</string>

--- a/src/huggle_l10n/Localization/en.xml
+++ b/src/huggle_l10n/Localization/en.xml
@@ -768,7 +768,10 @@
   <string name="speedy-progress">Tagging &apos;$1&apos; for speedy deletion...</string>
   <string name="speedy-notify-progress">Notifying the page creator...</string>
   <string name="speedy-creator-fail">Unable to determine the page creator: $1</string>
+  <string name="speedy-creator-empty">The page creator name was empty</string>
+  <string name="speedy-notification-create-fail">Unable to create the notification</string>
   <string name="speedy-notification-fail">The page was tagged for speedy deletion, but the creator could not be notified: $1</string>
+  <string name="speedy-failed">Failed</string>
   <string name="speedy-wrong">The requested tag is not valid. Please choose a different deletion reason</string>
   <string name="speedy-finished">Finished</string>
   <string name="warn-alreadyblocked">The user has already been blocked</string>

--- a/src/huggle_ui/mainwindow.cpp
+++ b/src/huggle_ui/mainwindow.cpp
@@ -633,6 +633,13 @@ void MainWindow::RequestPD(WikiEdit *edit)
     }
     if (edit == nullptr)
         edit = this->CurrentEdit;
+    if (this->fSpeedyDelete != nullptr && this->fSpeedyDelete->IsBusy())
+    {
+        this->fSpeedyDelete->show();
+        this->fSpeedyDelete->raise();
+        this->fSpeedyDelete->activateWindow();
+        return;
+    }
     delete this->fSpeedyDelete;
     this->fSpeedyDelete = new SpeedyForm(this);
     this->fSpeedyDelete->Init(edit);

--- a/src/huggle_ui/speedyform.cpp
+++ b/src/huggle_ui/speedyform.cpp
@@ -9,19 +9,29 @@
 //GNU General Public License for more details.
 
 #include "speedyform.hpp"
+#include <QCloseEvent>
 #include <QMessageBox>
+#include <QUrl>
+#include <huggle_core/apiquery.hpp>
 #include <huggle_core/configuration.hpp>
 #include <huggle_core/core.hpp>
+#include <huggle_core/editquery.hpp>
 #include <huggle_core/exception.hpp>
+#include <huggle_core/gc.hpp>
 #include <huggle_core/generic.hpp>
 #include <huggle_core/localization.hpp>
+#include <huggle_core/message.hpp>
+#include <huggle_core/projectconfiguration.hpp>
+#include <huggle_core/query.hpp>
 #include <huggle_core/syslog.hpp>
-#include <huggle_core/wikiuser.hpp>
+#include <huggle_core/wikiedit.hpp>
+#include <huggle_core/wikipage.hpp>
 #include <huggle_core/wikisite.hpp>
+#include <huggle_core/wikiuser.hpp>
 #include <huggle_core/wikiutil.hpp>
+#include "mainwindow.hpp"
 #include "uigeneric.hpp"
 #include "uihooks.hpp"
-#include "mainwindow.hpp"
 #include "ui_speedyform.h"
 
 using namespace Huggle;
@@ -38,6 +48,9 @@ SpeedyForm::SpeedyForm(QWidget *parent) : HW("speedyform", this, parent), ui(new
 
 SpeedyForm::~SpeedyForm()
 {
+    DetachCallback(this->qObtainText);
+    DetachCallback(this->Template);
+    DetachCallback(this->qFounder);
     delete this->ui;
 }
 
@@ -55,9 +68,7 @@ void SpeedyForm::on_btnTag_clicked()
     {
         QMessageBox::StandardButton qb = QMessageBox::question(MainWindow::HuggleMain, "Request",  _l("delete-user"), QMessageBox::Yes|QMessageBox::No);
         if (qb == QMessageBox::No)
-        {
             return;
-        }
     }
     if (this->ui->cbReason->currentText().isEmpty())
     {
@@ -70,63 +81,225 @@ void SpeedyForm::on_btnTag_clicked()
     this->ui->leParameter->setEnabled(false);
     this->ui->btnTag->setText(_l("speedy-progress", this->edit->Page->PageName));
     this->ui->btnTag->setEnabled(false);
+    this->ui->btnCancel->setEnabled(false);
     this->Header = this->ui->cbReason->currentText();
-    // first we need to retrieve the content of page if we don't have it already
+    this->busy = true;
+
     this->qObtainText = WikiUtil::RetrieveWikiPageContents(this->edit->Page);
-    this->timer->start(HUGGLE_TIMER);
+    this->qObtainText->CallbackOwner = this;
+    this->qObtainText->SuccessCallback = &SpeedyForm::ContentSuccess;
+    this->qObtainText->FailureCallback = &SpeedyForm::ContentFailure;
     this->qObtainText->Process();
 }
 
-void Finalize(Query *result)
+void *SpeedyForm::ContentSuccess(Query *query)
 {
-    SpeedyForm *form = reinterpret_cast<SpeedyForm*>(result->CallbackResult);
-    UiHooks::Speedy_Finished(form->edit, form->Header, true);
-    result->CallbackResult = nullptr;
-    result->UnregisterConsumer(HUGGLECONSUMER_CALLBACK);
-    form->close();
+    SpeedyForm *form = ReleaseCallback(query);
+    if (!form)
+        return nullptr;
+
+    bool failed = false;
+    form->Text = WikiUtil::EvaluateWikiPageContents(static_cast<ApiQuery*>(query), &failed, &form->base);
+    form->qObtainText.Delete();
+    if (failed)
+        form->Fail(form->Text);
+    else
+        form->processTags();
+    return nullptr;
 }
 
-void SpeedyForm::Fail(QString reason)
+void *SpeedyForm::ContentFailure(Query *query)
 {
-    this->qObtainText.Delete();
-    this->Template.Delete();
-    UiGeneric::MessageBox("Error", reason, MessageBoxStyleError);
-    UiHooks::Speedy_Finished(this->edit, this->ui->cbReason->currentText(), false);
+    SpeedyForm *form = ReleaseCallback(query);
+    if (!form)
+        return nullptr;
+
+    QString reason = query->GetFailureReason();
+    form->qObtainText.Delete();
+    form->Fail(reason);
+    return nullptr;
+}
+
+void *SpeedyForm::EditSuccess(Query *query)
+{
+    SpeedyForm *form = ReleaseCallback(query);
+    if (!form)
+        return nullptr;
+
+    form->Template.Delete();
+    form->tagSucceeded();
+    return nullptr;
+}
+
+void SpeedyForm::tagSucceeded()
+{
+    if (!this->ui->cbSendWarning->isChecked())
+        this->Finish();
+    else if (this->edit->Page->FounderKnown())
+        this->notifyFounder(this->edit->Page->GetFounder());
+    else
+        this->retrieveFounder();
+}
+
+void *SpeedyForm::EditFailure(Query *query)
+{
+    SpeedyForm *form = ReleaseCallback(query);
+    if (!form)
+        return nullptr;
+
+    QString reason = query->GetFailureReason();
+    form->Template.Delete();
+    form->Fail(reason);
+    return nullptr;
+}
+
+void *SpeedyForm::FounderSuccess(Query *query)
+{
+    SpeedyForm *form = ReleaseCallback(query);
+    if (!form)
+        return nullptr;
+
+    bool failed = false;
+    QString error;
+    QString founder = WikiUtil::EvaluatePageFounder(static_cast<ApiQuery*>(query)->GetApiQueryResult(), &failed, &error);
+    form->qFounder.Delete();
+    if (failed)
+    {
+        form->Fail(_l("speedy-creator-fail", error), true);
+        return nullptr;
+    }
+
+    form->edit->Page->SetFounder(founder);
+    form->notifyFounder(founder);
+    return nullptr;
+}
+
+void *SpeedyForm::FounderFailure(Query *query)
+{
+    SpeedyForm *form = ReleaseCallback(query);
+    if (!form)
+        return nullptr;
+
+    QString reason = query->GetFailureReason();
+    form->qFounder.Delete();
+    form->Fail(_l("speedy-creator-fail", reason), true);
+    return nullptr;
+}
+
+SpeedyForm *SpeedyForm::ReleaseCallback(Query *query)
+{
+    SpeedyForm *form = static_cast<SpeedyForm*>(query->CallbackOwner);
+    query->CallbackOwner = nullptr;
+    query->SuccessCallback = nullptr;
+    query->FailureCallback = nullptr;
+    query->UnregisterConsumer(HUGGLECONSUMER_CALLBACK);
+    return form;
+}
+
+void SpeedyForm::DetachCallback(Query *query)
+{
+    if (!query)
+        return;
+    query->CallbackOwner = nullptr;
+    query->SuccessCallback = nullptr;
+    query->FailureCallback = nullptr;
+}
+
+void SpeedyForm::Fail(const QString &reason, bool pageTagged)
+{
+    this->busy = false;
     this->timer->stop();
+    this->ui->btnCancel->setEnabled(true);
+    QString messageText = pageTagged ? _l("speedy-notification-fail", reason) : _l("speedy-fail", reason);
+    UiGeneric::MessageBox(_l("error"), messageText, MessageBoxStyleError, false, this);
+    UiHooks::Speedy_Finished(this->edit, this->Header, pageTagged);
+}
+
+void SpeedyForm::Finish()
+{
+    this->busy = false;
+    this->timer->stop();
+    this->ui->btnTag->setText(_l("speedy-finished"));
+    UiHooks::Speedy_Finished(this->edit, this->Header, true);
+    this->close();
 }
 
 void SpeedyForm::processTags()
 {
-    // insert the template to bottom of the page
     ProjectConfiguration::SpeedyOption speedy_option = this->edit->GetSite()->GetProjectConfig()->SpeedyTemplates.at(this->ui->cbReason->currentIndex());
-    //! \todo make this cross wiki instead of checking random tag
-    QString lower = this->Text;
-    lower = lower.toLower();
+    QString lower = this->Text.toLower();
     if (lower.contains("{{db"))
     {
         this->Fail(_l("speedy-csd-existing"));
-        this->close();
         return;
     }
     if (this->ReplacePage)
         this->Text = this->ReplacingText;
-    // insert a tag to page
     if (this->ui->leParameter->text().isEmpty())
         this->Text = "{{" + speedy_option.Template + "}}\n" + this->Text;
     else
         this->Text = "{{" + speedy_option.Template + "|" + this->ui->leParameter->text() + "}}\n" + this->Text;
-    // store a message we later send to user (we need to check if edit is successful first)
     this->warning = speedy_option.Msg;
-    // let's modify the page now
     QString summary = this->edit->GetSite()->GetProjectConfig()->SpeedyEditSummary;
     summary.replace("$1", this->edit->Page->PageName);
     this->Template = WikiUtil::EditPage(this->edit->Page, this->Text, summary, false, this->base);
-    this->Template->CallbackResult = reinterpret_cast<void*>(this);
-    this->Template->SuccessCallback = reinterpret_cast<Callback>(Finalize);
+    this->Template->CallbackOwner = this;
+    this->Template->SuccessCallback = &SpeedyForm::EditSuccess;
+    this->Template->FailureCallback = &SpeedyForm::EditFailure;
+    if (this->Template->IsProcessed())
+    {
+        bool failed = this->Template->IsFailed();
+        QString reason;
+        if (failed)
+            reason = this->Template->GetFailureReason();
+        DetachCallback(this->Template);
+        this->Template.Delete();
+        if (failed)
+            this->Fail(reason);
+        else
+            this->tagSucceeded();
+    }
+}
+
+void SpeedyForm::retrieveFounder()
+{
+    this->ui->btnTag->setText(_l("speedy-notify-progress"));
+    this->qFounder = new ApiQuery(ActionQuery, this->edit->GetSite());
+    this->qFounder->Parameters = "prop=revisions&titles=" + QUrl::toPercentEncoding(this->edit->Page->PageName) +
+                                "&rvdir=newer&rvlimit=1&rvprop=" + QUrl::toPercentEncoding("ids|user|timestamp");
+    this->qFounder->Target = this->edit->Page->PageName + " (retrieving founder)";
+    this->qFounder->CallbackOwner = this;
+    this->qFounder->SuccessCallback = &SpeedyForm::FounderSuccess;
+    this->qFounder->FailureCallback = &SpeedyForm::FounderFailure;
+    this->qFounder->Process();
+}
+
+void SpeedyForm::notifyFounder(const QString &founder)
+{
+    if (founder.isEmpty())
+    {
+        this->Fail(_l("speedy-creator-fail", "The founder name was empty"), true);
+        return;
+    }
+
+    this->ui->btnTag->setText(_l("speedy-notify-progress"));
+    QString summary = this->edit->GetSite()->GetProjectConfig()->SpeedyWarningSummary;
+    summary.replace("$1", this->edit->Page->PageName);
+    this->warning.replace("$1", this->edit->Page->PageName);
+    WikiUser creator(founder, this->edit->GetSite());
+    this->message = WikiUtil::MessageUser(&creator, this->warning, "", summary, false, nullptr, false, false, true);
+    if (this->message == nullptr)
+    {
+        this->Fail("Unable to create the notification", true);
+        return;
+    }
+    this->timer->start(HUGGLE_TIMER);
 }
 
 void SpeedyForm::on_btnCancel_clicked()
 {
+    if (this->busy)
+        return;
     this->timer->stop();
     this->close();
 }
@@ -134,14 +307,11 @@ void SpeedyForm::on_btnCancel_clicked()
 void SpeedyForm::Init(WikiEdit *edit_)
 {
     if (edit_ == nullptr)
-    {
         throw new Huggle::NullPointerException("WikiEdit *edit_", BOOST_CURRENT_FUNCTION);
-    }
+
     this->edit = edit_;
     for (const ProjectConfiguration::SpeedyOption& item : this->edit->GetSite()->GetProjectConfig()->SpeedyTemplates)
-    {
         this->ui->cbReason->addItem(item.Tag + ": " + item.Info);
-    }
     this->ui->lbInfo->setText(edit_->Page->PageName);
     this->ui->cbSendWarning->setChecked(edit_->GetSite()->GetProjectConfig()->Speedy_WarningOnByDefault);
     if (!edit_->GetSite()->GetProjectConfig()->Speedy_EnableWarnings)
@@ -168,41 +338,34 @@ void SpeedyForm::SetMessageUserCheck(bool new_value)
 
 void SpeedyForm::OnTick()
 {
-    if (this->qObtainText != nullptr)
+    if (this->message == nullptr || !this->message->IsFinished())
+        return;
+
+    if (this->message->IsFailed())
     {
-        if (!this->qObtainText->IsProcessed()) { return; }
-        bool failed = false;
-        this->Text = WikiUtil::EvaluateWikiPageContents(this->qObtainText, &failed, &this->base);
-        if (failed)
-        {
-            this->Fail(this->Text);
-            return;
-        }
-        this->qObtainText = nullptr;
-        this->processTags();
+        QString reason = this->message->ErrorText;
+        this->message.Delete();
+        this->Fail(reason, true);
+    } else
+    {
+        this->message.Delete();
+        this->Finish();
+    }
+}
+
+bool SpeedyForm::IsBusy() const
+{
+    return this->busy;
+}
+
+void SpeedyForm::closeEvent(QCloseEvent *event)
+{
+    if (this->busy)
+    {
+        event->ignore();
         return;
     }
-    if (this->Template != nullptr)
-    {
-        if (this->Template->IsProcessed())
-        {
-            if(this->Template->IsFailed())
-            {
-                this->Fail(_l("speedy-fail", this->Template->GetFailureReason()));
-                return;
-            }
-            this->Template = nullptr;
-            if (this->ui->cbSendWarning->isChecked())
-            {
-                QString summary = this->edit->GetSite()->GetProjectConfig()->SpeedyWarningSummary;
-                summary.replace("$1", this->edit->Page->PageName);
-                this->warning.replace("$1", this->edit->Page->PageName);
-                WikiUtil::MessageUser(this->edit->User, this->warning, "", summary, false);
-            }
-            this->timer->stop();
-            this->ui->btnTag->setText(_l("speedy-finished"));
-        }
-    }
+    HW::closeEvent(event);
 }
 
 void Huggle::SpeedyForm::on_cbReason_currentIndexChanged(int index)

--- a/src/huggle_ui/speedyform.cpp
+++ b/src/huggle_ui/speedyform.cpp
@@ -66,7 +66,7 @@ void SpeedyForm::on_btnTag_clicked()
         return;
     if (this->edit->Page->IsUserpage())
     {
-        QMessageBox::StandardButton qb = QMessageBox::question(MainWindow::HuggleMain, "Request",  _l("delete-user"), QMessageBox::Yes|QMessageBox::No);
+        QMessageBox::StandardButton qb = QMessageBox::question(MainWindow::HuggleMain, _l("request"),  _l("delete-user"), QMessageBox::Yes|QMessageBox::No);
         if (qb == QMessageBox::No)
             return;
     }
@@ -209,6 +209,7 @@ void SpeedyForm::Fail(const QString &reason, bool pageTagged)
 {
     this->busy = false;
     this->timer->stop();
+    this->ui->btnTag->setText(_l("speedy-failed"));
     this->ui->btnCancel->setEnabled(true);
     QString messageText = pageTagged ? _l("speedy-notification-fail", reason) : _l("speedy-fail", reason);
     UiGeneric::MessageBox(_l("error"), messageText, MessageBoxStyleError, false, this);
@@ -278,7 +279,7 @@ void SpeedyForm::notifyFounder(const QString &founder)
 {
     if (founder.isEmpty())
     {
-        this->Fail(_l("speedy-creator-fail", "The founder name was empty"), true);
+        this->Fail(_l("speedy-creator-empty"), true);
         return;
     }
 
@@ -290,7 +291,7 @@ void SpeedyForm::notifyFounder(const QString &founder)
     this->message = WikiUtil::MessageUser(&creator, this->warning, "", summary, false, nullptr, false, false, true);
     if (this->message == nullptr)
     {
-        this->Fail("Unable to create the notification", true);
+        this->Fail(_l("speedy-notification-create-fail"), true);
         return;
     }
     this->timer->start(HUGGLE_TIMER);

--- a/src/huggle_ui/speedyform.cpp
+++ b/src/huggle_ui/speedyform.cpp
@@ -192,7 +192,11 @@ SpeedyForm *SpeedyForm::ReleaseCallback(Query *query)
     query->CallbackOwner = nullptr;
     query->SuccessCallback = nullptr;
     query->FailureCallback = nullptr;
-    query->UnregisterConsumer(HUGGLECONSUMER_CALLBACK);
+    // Query completion code can continue using the query after invoking its callback.
+    QTimer::singleShot(0, [query]()
+    {
+        query->UnregisterConsumer(HUGGLECONSUMER_CALLBACK);
+    });
     return form;
 }
 
@@ -213,6 +217,7 @@ void SpeedyForm::Fail(const QString &reason, bool pageTagged)
     this->ui->btnCancel->setEnabled(true);
     QString messageText = pageTagged ? _l("speedy-notification-fail", reason) : _l("speedy-fail", reason);
     UiGeneric::MessageBox(_l("error"), messageText, MessageBoxStyleError, false, this);
+    // The hook reports whether the page was tagged; creator notification is best-effort.
     UiHooks::Speedy_Finished(this->edit, this->Header, pageTagged);
 }
 

--- a/src/huggle_ui/speedyform.hpp
+++ b/src/huggle_ui/speedyform.hpp
@@ -16,6 +16,7 @@
 #include <QTimer>
 #include "hw.hpp"
 #include <huggle_core/collectable_smartptr.hpp>
+#include <huggle_core/message.hpp>
 #include <huggle_core/wikiedit.hpp>
 
 class QCloseEvent;
@@ -31,7 +32,6 @@ namespace Huggle
     class WikiUser;
     class ApiQuery;
     class EditQuery;
-    class Message;
     class Query;
 
     /*!

--- a/src/huggle_ui/speedyform.hpp
+++ b/src/huggle_ui/speedyform.hpp
@@ -15,7 +15,9 @@
 
 #include <QTimer>
 #include "hw.hpp"
+#include <huggle_core/apiquery.hpp>
 #include <huggle_core/collectable_smartptr.hpp>
+#include <huggle_core/editquery.hpp>
 #include <huggle_core/message.hpp>
 #include <huggle_core/wikiedit.hpp>
 
@@ -30,8 +32,6 @@ namespace Huggle
 {
     class WikiEdit;
     class WikiUser;
-    class ApiQuery;
-    class EditQuery;
     class Query;
 
     /*!

--- a/src/huggle_ui/speedyform.hpp
+++ b/src/huggle_ui/speedyform.hpp
@@ -15,10 +15,10 @@
 
 #include <QTimer>
 #include "hw.hpp"
-#include <huggle_core/apiquery.hpp>
 #include <huggle_core/collectable_smartptr.hpp>
-#include <huggle_core/editquery.hpp>
 #include <huggle_core/wikiedit.hpp>
+
+class QCloseEvent;
 
 namespace Ui
 {
@@ -31,6 +31,8 @@ namespace Huggle
     class WikiUser;
     class ApiQuery;
     class EditQuery;
+    class Message;
+    class Query;
 
     /*!
      * \brief The window that is used to report a page for deletion
@@ -43,11 +45,12 @@ namespace Huggle
             Q_OBJECT
         public:
             explicit SpeedyForm(QWidget *parent = nullptr);
-            ~SpeedyForm();
+            ~SpeedyForm() override;
             void Init(WikiEdit *edit_);
             QString GetSelectedDBReason();
             QString GetSelectedTagID();
             void SetMessageUserCheck(bool new_value);
+            bool IsBusy() const;
             bool ReplacePage = false;
             QString ReplacingText;
             Collectable_SmartPtr<WikiEdit> edit;
@@ -61,16 +64,30 @@ namespace Huggle
             void on_cbReason_currentIndexChanged(int index);
 
         private:
-            void Fail(QString reason);
+            static void *ContentSuccess(Query *query);
+            static void *ContentFailure(Query *query);
+            static void *EditSuccess(Query *query);
+            static void *EditFailure(Query *query);
+            static void *FounderSuccess(Query *query);
+            static void *FounderFailure(Query *query);
+            static SpeedyForm *ReleaseCallback(Query *query);
+            static void DetachCallback(Query *query);
+            void closeEvent(QCloseEvent *event) override;
+            void Fail(const QString &reason, bool pageTagged = false);
+            void Finish();
             void processTags();
+            void tagSucceeded();
+            void retrieveFounder();
+            void notifyFounder(const QString &founder);
             Collectable_SmartPtr<EditQuery> Template;
             Collectable_SmartPtr<ApiQuery> qObtainText;
+            Collectable_SmartPtr<ApiQuery> qFounder;
+            Collectable_SmartPtr<Message> message;
             QString base;
             QString warning;
             QTimer *timer;
             Ui::SpeedyForm *ui;
+            bool busy = false;
     };
 }
 #endif // SPEEDYFORM_H
-
-

--- a/src/tests/test/tst_testmain.cpp
+++ b/src/tests/test/tst_testmain.cpp
@@ -24,6 +24,8 @@
 #include <huggle_core/query.hpp>
 #include <huggle_core/querypool.hpp>
 #include <huggle_core/events.hpp>
+#include <huggle_core/apiqueryresult.hpp>
+#include <huggle_core/wikiutil.hpp>
 
 class TestQuery : public Huggle::Query
 {
@@ -81,6 +83,7 @@ class HuggleTest : public QObject
         void testCaseVersionComparison();
         void testCaseGenerics();
         void testCaseWikiPage();
+        void testCasePageFounderResult();
         void testCaseQueryPoolFinishedQueryWithoutResult();
         void testCaseQueryTimeoutRetriesOnce();
 };
@@ -255,6 +258,27 @@ void HuggleTest::testCaseWikiUserCheckIP()
     QVERIFY2((Huggle::WikiUser("~2025-33137-16", hcfg->Project).IsAnon() == true), "Invalid result for new WikiUser with username of ~2025-33137-16, the result of IsAnon() was false, but should have been true");
     QVERIFY2((Huggle::WikiUser("~2025-31256-01", hcfg->Project).IsAnon() == true), "Invalid result for new WikiUser with username of ~2025-31256-01, the result of IsAnon() was false, but should have been true");
     QVERIFY2((Huggle::WikiUser("~20256-31256-04561", hcfg->Project).IsAnon() == false), "Invalid result for new WikiUser with username of ~20256-31256-04561, the result of IsAnon() was true, but should have been false");
+}
+
+void HuggleTest::testCasePageFounderResult()
+{
+    Huggle::ApiQueryResult result;
+    result.Data = "<api><query><pages><page><revisions><rev revid=\"1\" user=\"Page creator\" timestamp=\"2021-01-01T00:00:00Z\" /></revisions></page></pages></query></api>";
+    result.Process();
+
+    bool failed;
+    QString error;
+    QCOMPARE(Huggle::WikiUtil::EvaluatePageFounder(&result, &failed, &error), QString("Page creator"));
+    QVERIFY(!failed);
+    QVERIFY(error.isEmpty());
+
+    Huggle::ApiQueryResult missingFounder;
+    missingFounder.Data = "<api><query><pages><page><revisions><rev revid=\"1\" timestamp=\"2021-01-01T00:00:00Z\" /></revisions></page></pages></query></api>";
+    missingFounder.Process();
+
+    QVERIFY(Huggle::WikiUtil::EvaluatePageFounder(&missingFounder, &failed, &error).isEmpty());
+    QVERIFY(failed);
+    QVERIFY(!error.isEmpty());
 }
 
 void HuggleTest::testCaseQueryPoolFinishedQueryWithoutResult()


### PR DESCRIPTION
The speedy-deletion dialog previously polled query state, closed before every stage had completed, and could silently miss edit failures. When creator notifications were enabled, it also warned the author of the displayed edit rather than the user who created the page. Reopening the dialog while work was pending could additionally leave callbacks targeting a deleted form.

This changes the query stages to use completion callbacks, keeps the form alive and non-dismissible while work is active, and reports tagging and notification failures separately. It retrieves and caches the first revision when needed, uses that page creator for the warning, and centralizes founder parsing so postprocessing and speedy deletion share the same behavior. Regression coverage includes valid and missing founder responses.

The Qt 6 release build and test suite pass. A live test on Test Wikipedia confirmed that the page was tagged, the original creator was notified, the latest editor was not notified, and the form waited for notification completion.

Phabricator: https://phabricator.wikimedia.org/T293336